### PR TITLE
(maint) Add Beaker gem release Github action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    if: github.repository == 'voxpupuli/beaker'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -21,4 +22,3 @@ jobs:
           RUBYGEMS_AUTH_TOKEN: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}
         with:
           args: push *.gem
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Release the gem
+
+on:
+  create:
+    ref_type: tag
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Build gem
+        uses: scarhand/actions-ruby@master
+        with:
+          args: build *.gemspec
+      - name: Publish gem
+        uses: scarhand/actions-ruby@master
+        env:
+          RUBYGEMS_AUTH_TOKEN: ${{ secrets.RUBYGEMS_AUTH_TOKEN }}
+        with:
+          args: push *.gem
+


### PR DESCRIPTION
This adds a new Github action workflow to release Beaker to
rubygems.org. It's triggered when a new tag is created, and uses the
`RUBYGEMS_AUTH_TOKEN` secret on this repository to push the built gem to
rubygems.org.

NOTE: This WON'T WORK and will be really annoying to see errors on before this repo has the auth token secret for VoxPupuli rubygems owner. This PR can be transfered when the repo is transfered, so it's probably best to leave this open until after the transfer is complete and Vox has added their auth token.