### PR TITLE
(BKR-1675) Add net-scp 3.x compatibility

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'hocon', '~> 1.0'
   s.add_runtime_dependency 'net-ssh', '>= 5.0'
-  s.add_runtime_dependency 'net-scp', '~> 1.2'
+  s.add_runtime_dependency 'net-scp', '~> 3.0'
   s.add_runtime_dependency 'inifile', '~> 3.0'
 
   s.add_runtime_dependency 'rsync', '~> 1.0.9'


### PR DESCRIPTION
Not sure if specs cover this update but there is no test failure after updating `net-scp` to the latest version.