### PR TITLE
Fix UNIX reboot check granularity

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --format documentation
 --color
 --tty
+--fail-fast


### PR DESCRIPTION
Tries a more granular method for getting the seconds on a reboot.

Failing that, falls back to 'who -b' and sleeps for the remaining
seconds up to the next minute plus one to ensure that the reboot time
gets updated sufficiently.

Fixes #1674