### PR TITLE
(maint) wrap paths around "" on pswindows

### DIFF
--- a/lib/beaker/host/pswindows/exec.rb
+++ b/lib/beaker/host/pswindows/exec.rb
@@ -22,7 +22,7 @@ module PSWindows::Exec
   def rm_rf path
     # ensure that we have the right slashes for windows
     path = path.gsub(/\//, '\\')
-    execute("del /s /q #{path}")
+    execute(%(del /s /q "#{path}"))
   end
 
   # Move the origin to destination. The destination is removed prior to moving.

--- a/spec/beaker/host/pswindows/exec_spec.rb
+++ b/spec/beaker/host/pswindows/exec_spec.rb
@@ -29,8 +29,8 @@ module Beaker
       it "deletes" do
         path = '/path/to/delete'
         corrected_path = '\\path\\to\\delete'
-        expect( instance ).to receive(:execute).with("del /s /q #{corrected_path}").and_return(0)
-        expect( instance.rm_rf(path) ).to be === 0
+        expect(instance).to receive(:execute).with(%(del /s /q "#{corrected_path}")).and_return(0)
+        expect(instance.rm_rf(path)).to eq(0)
       end
     end
 
@@ -39,10 +39,9 @@ module Beaker
       let(:destination) { '/destination/path/of/content' }
 
       it 'rm first' do
-        expect( instance ).to receive(:execute).with("del /s /q #{destination.gsub(/\//, '\\')}").and_return(0)
-        expect( instance ).to receive(:execute).with("move /y #{origin.gsub(/\//, '\\')} #{destination.gsub(/\//, '\\')}").and_return(0)
-        expect( instance.mv(origin, destination) ).to be === 0
-
+        expect(instance).to receive(:execute).with("del /s /q \"\\destination\\path\\of\\content\"").and_return(0)
+        expect(instance).to receive(:execute).with("move /y #{origin.gsub(/\//, '\\')} #{destination.gsub(/\//, '\\')}").and_return(0)
+        expect(instance.mv(origin, destination)).to eq(0)
       end
 
       it 'does not rm' do


### PR DESCRIPTION
If the specified path for deletion contains spaces,
the del command will fail with being unable to find
the specified path. Wrap the path around "" in order
for the path to be recognised.

This fixes https://github.com/puppetlabs/facter/pull/1992/checks

error:
```
Test Case tests/options/config_file/no_custom_facts_and_load_path.rb reported: #<Beaker::Host::CommandFailure: Host 'localhost' exited with 1 running:
 del /s /q C:\Program Files\Puppet Labs\Puppet\puppet\lib\ruby\gems\2.5.0\gems\did_you_mean-1.2.0\lib\facter
Last 10 lines of output were:
```