### PR TITLE
(maint) Show execute results on local connection

### DIFF
--- a/lib/beaker/local_connection.rb
+++ b/lib/beaker/local_connection.rb
@@ -53,9 +53,12 @@ module Beaker
           result.stdout << std_out
           result.stderr << std_err
           result.exit_code = status.exitstatus
+          @logger.info(result.stdout)
+          @logger.info(result.stderr)
         end
       rescue => e
         result.stderr << e.inspect
+        @logger.info(result.stderr)
         result.exit_code = 1
       end
 


### PR DESCRIPTION
When executing commands through the local connection, their output is only transmitted as an output,
but it's not showed in the terminal.
As a fix, we now use the logger to print the result for us.