### PR TITLE
Loosen fakefs dependency

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   # Testing dependencies
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its'
-  s.add_development_dependency 'fakefs', '~> 1.2', '< 1.3.0'
+  s.add_development_dependency 'fakefs', '~> 1.0'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'rake', '~> 13.0'
 


### PR DESCRIPTION
Prior to f70f673ec3da78a3dcb075ccda637b5a2a923fd3, it was not accepting any 1.x version. It should be safe to assume FakeFS follows semver and any 1.x version will do.