### PR TITLE
(maint) update ssh_preference example

### DIFF
--- a/docs/how_to/ssh_connection_preference.md
+++ b/docs/how_to/ssh_connection_preference.md
@@ -30,7 +30,10 @@ HOSTS:
     hypervisor: vmpooler
     platform: ubuntu-16.04-amd64
     template: ubuntu-1604-x86_64
-    ssh_preference: [:vmhostname, :hostname, :ip]
+    ssh_preference:
+    - :vmhostname
+    - :hostname
+    - :ip
     roles:
     - agent
     - default


### PR DESCRIPTION
Prior to this commit, the provided example was invalid YAML. This
commit fixes the example host file so that it is parseable.