### PR TITLE
(BKR-1690) Fix localhost logging

### DIFF
--- a/lib/beaker/local_connection.rb
+++ b/lib/beaker/local_connection.rb
@@ -53,9 +53,12 @@ module Beaker
           result.stdout << std_out
           result.stderr << std_err
           result.exit_code = status.exitstatus
+          @logger.info(result.stdout) unless result.stdout.empty?
+          @logger.info(result.stderr) unless result.stderr.empty?
         end
       rescue => e
         result.stderr << e.inspect
+        @logger.info(result.stderr)
         result.exit_code = 1
       end
 


### PR DESCRIPTION
When running tests on localhost we don't see the output from the commands we run,
as beaker normally does, by default, on provisioned machines. 
As a fix I added logging messages.