### PR TITLE
Fix the 'which' command

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -456,9 +456,19 @@ module Unix::Exec
   #@example
   #  host.which('ruby')
   def which(command)
-    which_command = "which #{command}"
+    unless @which_command
+      if execute('type -P true', :accept_all_exit_codes => true).empty?
+        if execute('which true', :accept_all_exit_codes => true).empty?
+          raise ArgumentError, "Could not find suitable 'which' command"
+        else
+          @which_command = 'which'
+        end
+      else
+        @which_command = 'type -P'
+      end
+    end
 
-    result = execute(which_command, :accept_all_exit_codes => true)
+    result = execute("#{@which_command} #{command}", :accept_all_exit_codes => true)
     return '' if result.empty?
 
     result

--- a/spec/beaker/host/unix/exec_spec.rb
+++ b/spec/beaker/host/unix/exec_spec.rb
@@ -169,52 +169,54 @@ module Beaker
     end
 
     describe '#reboot' do
+      year = Time.now.strftime('%Y')
+
       check_cmd_output = {
         :centos6 => {
           :who => {
-            :initial => '      system boot  2020-05-13 03:51',
-            :success => '      system boot  2020-05-13 03:52',
+            :initial => "      system boot  #{year}-05-13 03:51",
+            :success => "      system boot  #{year}-05-13 03:52",
           },
           :last => {
               :initial => <<~LAST_F,
-              reboot   system boot  2.6.32-754.29.1. Tue May 5 17:34:52 2020 - Tue May 5 17:52:48 2020  (00:17)
-              reboot   system boot  2.6.32-754.29.1. Mon May 4 18:45:43 2020 - Mon May 5 05:35:44 2020 (4+01:50)
+              reboot   system boot  2.6.32-754.29.1. Tue May 5 17:34:52 #{year} - Tue May 5 17:52:48 #{year}  (00:17)
+              reboot   system boot  2.6.32-754.29.1. Mon May 4 18:45:43 #{year} - Mon May 5 05:35:44 #{year} (4+01:50)
               LAST_F
               :success => <<~LAST_F,
-              reboot   system boot  2.6.32-754.29.1. Tue May 5 17:52:48 2020 - Tue May 5 17:52:49 2020  (00:17)
-              reboot   system boot  2.6.32-754.29.1. Mon May 4 18:45:43 2020 - Mon May 5 05:35:44 2020 (4+01:50)
+              reboot   system boot  2.6.32-754.29.1. Tue May 5 17:52:48 #{year} - Tue May 5 17:52:49 #{year}  (00:17)
+              reboot   system boot  2.6.32-754.29.1. Mon May 4 18:45:43 #{year} - Mon May 5 05:35:44 #{year} (4+01:50)
               LAST_F
           },
         },
         :centos7 => {
           :who => {
-            :initial => '      system boot  2020-05-13 03:51',
-            :success => '      system boot  2020-05-13 03:52',
+            :initial => "      system boot  #{year}-05-13 03:51",
+            :success => "      system boot  #{year}-05-13 03:52",
           },
           :last => {
               :initial => <<~LAST_F,
-              reboot   system boot  3.10.0-1127.el7. Tue May 5 17:34:52 2020 - Tue May 5 17:52:48 2020  (00:17)
-              reboot   system boot  3.10.0-1127.el7. Mon May 4 18:45:43 2020 - Mon May 5 05:35:44 2020 (4+01:50)
+              reboot   system boot  3.10.0-1127.el7. Tue May 5 17:34:52 #{year} - Tue May 5 17:52:48 #{year}  (00:17)
+              reboot   system boot  3.10.0-1127.el7. Mon May 4 18:45:43 #{year} - Mon May 5 05:35:44 #{year} (4+01:50)
               LAST_F
               :success => <<~LAST_F,
-              reboot   system boot  3.10.0-1127.el7. Tue May 5 17:52:48 2020 - Tue May 5 17:52:49 2020  (00:17)
-              reboot   system boot  3.10.0-1127.el7. Mon May 4 18:45:43 2020 - Mon May 5 05:35:44 2020 (4+01:50)
+              reboot   system boot  3.10.0-1127.el7. Tue May 5 17:52:48 #{year} - Tue May 5 17:52:49 #{year}  (00:17)
+              reboot   system boot  3.10.0-1127.el7. Mon May 4 18:45:43 #{year} - Mon May 5 05:35:44 #{year} (4+01:50)
               LAST_F
           },
         },
         :centos8 => {
           :who => {
-            :initial => '      system boot  2020-05-13 03:51',
-            :success => '      system boot  2020-05-13 03:52',
+            :initial => "      system boot  #{year}-05-13 03:51",
+            :success => "      system boot  #{year}-05-13 03:52",
           },
           :last => {
               :initial => <<~LAST_F,
-              reboot   system boot  4.18.0-147.8.1.e Tue May 5 17:34:52 2020 still running
-              reboot   system boot  4.18.0-147.8.1.e Mon May 4 17:41:27 2020 - Tue May 5 17:00:00 2020 (5+00:11)
+              reboot   system boot  4.18.0-147.8.1.e Tue May 5 17:34:52 #{year} still running
+              reboot   system boot  4.18.0-147.8.1.e Mon May 4 17:41:27 #{year} - Tue May 5 17:00:00 #{year} (5+00:11)
               LAST_F
               :success => <<~LAST_F,
-              reboot   system boot  4.18.0-147.8.1.e Tue May 5 17:34:53 2020 still running
-              reboot   system boot  4.18.0-147.8.1.e Mon May 4 17:41:27 2020 - Tue May 5 17:00:00 2020 (5+00:11)
+              reboot   system boot  4.18.0-147.8.1.e Tue May 5 17:34:53 #{year} still running
+              reboot   system boot  4.18.0-147.8.1.e Mon May 4 17:41:27 #{year} - Tue May 5 17:00:00 #{year} (5+00:11)
               LAST_F
           },
         },
@@ -258,8 +260,8 @@ module Beaker
                 expect(instance).to receive(:sleep).with(sleep_time)
                 # bypass shutdown command itself
                 expect(instance).to receive( :exec ).with(:shutdown_command_stub, anything).and_return(response)
-                # allow the second boot_time and the hash arguments in exec
                 expect(instance).to receive( :exec ).with(:boot_time_command_stub, anything).and_return(boot_time_initial_response).once
+                # allow the second boot_time and the hash arguments in exec
                 expect(instance).to receive( :exec ).with(:boot_time_command_stub, anything).and_return(boot_time_success_response).once
 
                 expect(instance.reboot).to be(nil)
@@ -384,30 +386,86 @@ module Beaker
     end
 
     describe '#which' do
-      before do
-        allow(instance).to receive(:execute)
-                               .with(where_command, :accept_all_exit_codes => true).and_return(result)
-      end
+      context 'when type -P works' do
+        before do
+          expect(instance).to receive(:execute)
+            .with('type -P true', :accept_all_exit_codes => true).and_return('/bin/true').once
 
-      context 'when only the environment variable PATH is used' do
-        let(:where_command) { "which ruby" }
-        let(:result) { "/usr/bin/ruby.exe" }
+          allow(instance).to receive(:execute)
+                                 .with(where_command, :accept_all_exit_codes => true).and_return(result)
+        end
 
-        it 'returns the correct path' do
-          response = instance.which('ruby')
+        context 'when only the environment variable PATH is used' do
+          let(:where_command) { "type -P ruby" }
+          let(:result) { "/usr/bin/ruby.exe" }
 
-          expect(response).to eq(result)
+          it 'returns the correct path' do
+            response = instance.which('ruby')
+
+            expect(response).to eq(result)
+          end
+        end
+
+        context 'when command is not found' do
+          let(:where_command) { "type -P unknown" }
+          let(:result) { '' }
+
+          it 'return empty string if command is not found' do
+            response = instance.which('unknown')
+
+            expect(response).to eq(result)
+          end
         end
       end
 
-      context 'when command is not found' do
-        let(:where_command) { "which unknown" }
-        let(:result) { '' }
+      context 'when which works' do
+        before do
+          expect(instance).to receive(:execute)
+            .with('type -P true', :accept_all_exit_codes => true).and_return('').once
 
-        it 'return empty string if command is not found' do
-          response = instance.which('unknown')
+          expect(instance).to receive(:execute)
+            .with('which true', :accept_all_exit_codes => true).and_return('/bin/true').once
 
-          expect(response).to eq(result)
+          allow(instance).to receive(:execute)
+                                 .with(where_command, :accept_all_exit_codes => true).and_return(result)
+        end
+
+        context 'when only the environment variable PATH is used' do
+          let(:where_command) { "which ruby" }
+          let(:result) { "/usr/bin/ruby.exe" }
+
+          it 'returns the correct path' do
+            response = instance.which('ruby')
+
+            expect(response).to eq(result)
+          end
+        end
+
+        context 'when command is not found' do
+          let(:where_command) { "which unknown" }
+          let(:result) { '' }
+
+          it 'return empty string if command is not found' do
+            response = instance.which('unknown')
+
+            expect(response).to eq(result)
+          end
+        end
+      end
+
+      context 'when neither works' do
+        before do
+          expect(instance).to receive(:execute)
+            .with('type -P true', :accept_all_exit_codes => true).and_return('').once
+
+          expect(instance).to receive(:execute)
+            .with('which true', :accept_all_exit_codes => true).and_return('').once
+        end
+
+        context 'when only the environment variable PATH is used' do
+          it 'fails correctly' do
+            expect{instance.which('ruby')}.to raise_error(/suitable/)
+          end
         end
       end
     end

--- a/spec/beaker/options/subcommand_options_parser_spec.rb
+++ b/spec/beaker/options/subcommand_options_parser_spec.rb
@@ -4,8 +4,9 @@ module Beaker
   module Options
     describe '#parse_subcommand_options' do
       let(:home_options_file_path) {ENV['HOME']+'/.beaker/subcommand_options.yaml'}
-      let( :parser ) {Beaker::Options::SubcommandOptionsParser.parse_subcommand_options(argv, options_file)}
-      let( :file_parser ){Beaker::Options::SubcommandOptionsParser.parse_options_file({})}
+      let(:parser_mod) { Beaker::Options::SubcommandOptionsParser }
+      let( :parser ) {parser_mod.parse_subcommand_options(argv, options_file)}
+      let( :file_parser ){parser_mod.parse_options_file({})}
       let( :argv ) {[]}
       let( :options_file ) {""}
 
@@ -26,14 +27,14 @@ module Beaker
         let( :argv ) {['provision']}
         let(:options_file) {Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS}
         it 'calls parse_options_file with subcommand options file when home_dir is false' do
-          allow(parser).to receive(:execute_subcommand?).with('provision').and_return true
-          allow(parser).to receive(:parse_options_file).with(Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS)
+          allow(parser_mod).to receive(:execute_subcommand?).with('provision').and_return true
+          allow(parser_mod).to receive(:parse_options_file).with(Beaker::Subcommands::SubcommandUtil::SUBCOMMAND_OPTIONS)
         end
 
         let( :options_file ) {home_options_file_path}
         it 'calls parse_options_file with home directory options file when home_dir is true' do
-          allow(parser).to receive(:execute_subcommand?).with('provision').and_return true
-          allow(parser).to receive(:parse_options_file).with(home_options_file_path)
+          allow(parser_mod).to receive(:execute_subcommand?).with('provision').and_return true
+          allow(parser_mod).to receive(:parse_options_file).with(home_options_file_path)
         end
 
         it 'checks for file existence and loads the YAML file' do
@@ -49,7 +50,6 @@ module Beaker
           expect(parser).to be_kind_of(OptionsHash)
           expect(parser).to be_empty
         end
-
       end
     end
   end


### PR DESCRIPTION
Fixed:
  * Modify `which()` to do the following
    * Try `type -P` first
    * Fall back to `which`
    * Fail if nothing is found
  * Fixed the dates in the mock reboot test data
  * Updated the subcommand_options_parser tests to properly isolate the
    module stubs for Rspec 3.10