### PR TITLE
Support Ruby 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
           - "2.5"
           - "2.6"
           - "2.7"
+          - "3.0"
     name: Ruby ${{ matrix.ruby }}
     steps:
       - uses: actions/checkout@v2

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'pry-byebug', '~> 3.9'
   # pry-byebug can have issues with native readline libs so add rb-readline
   s.add_runtime_dependency 'rb-readline', '~> 0.5.3'
+  s.add_runtime_dependency 'rexml'
 
   s.add_runtime_dependency 'hocon', '~> 1.0'
   s.add_runtime_dependency 'net-ssh', '>= 5.0'

--- a/lib/beaker/dsl/helpers/web_helpers.rb
+++ b/lib/beaker/dsl/helpers/web_helpers.rb
@@ -107,12 +107,11 @@ module Beaker
           logger.notify "  and saving to #{dst}"
           logger.notify "  using command: #{wget_command}"
 
-          #in ruby 1.9+ we can upgrade this to popen3 to gain access to the subprocess pid
-          result = `#{wget_command} 2>&1`
-          result.each_line do |line|
+          stdout_and_stderr_str, status = Open3.capture2e(wget_command)
+          stdout_and_stderr_str.each_line do |line|
             logger.debug(line)
           end
-          if $?.to_i != 0
+          unless status.success?
             raise "Failed to fetch_remote_dir '#{url}' (exit code #{$?})"
           end
           dst

--- a/spec/beaker/dsl/helpers/web_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/web_helpers_spec.rb
@@ -89,6 +89,7 @@ describe ClassMixedWithDSLHelpers do
   describe "#fetch_http_dir" do
     let( :logger) { double("Beaker::Logger", :notify => nil , :debug => nil ) }
     let( :result) { double(:each_line => []) }
+    let( :status) { double('Process::Status', success?: true) }
 
     before do
       fetch_allows
@@ -97,8 +98,7 @@ describe ClassMixedWithDSLHelpers do
     describe "given valid arguments" do
 
       it "returns basename of first argument concatenated to second." do
-        expect(subject).to receive(:`).with(/^wget.*/).ordered { result }
-        expect($?).to receive(:to_i).and_return(0)
+        expect(Open3).to receive(:capture2e).with(/^wget.*/).ordered { result }.and_return(['', status])
         result = subject.fetch_http_dir "#{url}/beep", destdir
         expect(result).to eq("#{destdir}/beep")
       end


### PR DESCRIPTION
In Ruby 3.0 rexml is no longer bundled. This adds it as an explicit dependency.

<del>I fear this may break Ruby 2.4 but we'll see what CI says.</del>