### PR TITLE
Use chrony instead of ntpdate on Fedora

### DIFF
--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -13,6 +13,7 @@ module Beaker
     SLEEPWAIT = 5
     TRIES = 5
     RHEL8_PACKAGES = ['curl', 'chrony']
+    FEDORA_PACKAGES = ['curl', 'chrony']
     UNIX_PACKAGES = ['curl', 'ntpdate']
     FREEBSD_PACKAGES = ['curl', 'perl5|perl']
     OPENBSD_PACKAGES = ['curl']
@@ -52,7 +53,7 @@ module Beaker
           logger.notify "NTP date succeeded on #{host}"
         else
           case
-          when host['platform'] =~ /el-8/
+          when host['platform'] =~ /el-8|fedora/
             ntp_command = "chronyc add server #{ntp_server} prefer trust;chronyc makestep;chronyc burst 1/2"
           when host['platform'] =~ /sles-/
             ntp_command = "sntp #{ntp_server}"
@@ -126,6 +127,8 @@ module Beaker
           check_and_install_packages_if_needed(host, SOLARIS11_PACKAGES)
         when host['platform'] =~ /archlinux/
           check_and_install_packages_if_needed(host, ARCHLINUX_PACKAGES)
+        when host['platform'] =~ /fedora/
+          check_and_install_packages_if_needed(host, FEDORA_PACKAGES)
         when host['platform'] !~ /debian|aix|solaris|windows|sles-|osx-|cumulus|f5-|netscaler|cisco_/
           check_and_install_packages_if_needed(host, UNIX_PACKAGES)
         end


### PR DESCRIPTION
The ntpdate package is no longer available starting with Fedora 34, the ntpdate binary is now provided by the ntpsec package.

Since chrony seems to be the preferred way of synchronizing time, use it on all Fedora. We tested this internally and the chrony package comes preinstalled since at least Fedora 30.