### PR TITLE
beaker-abs: allow latest releases

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   # Provisioner dependencies - needed for acceptance tests
   # TODO: figure out how to remove these
   s.add_development_dependency 'beaker-aws', '~> 0.1'
-  s.add_development_dependency 'beaker-abs', '~> 0.4'
+  s.add_development_dependency 'beaker-abs', '>= 0.4'
   s.add_development_dependency 'beaker-vmpooler', '~> 1.0'
 
   # Documentation dependencies


### PR DESCRIPTION
beaker was pinned to 0.4.x, but the last release is 0.8.1