### PR TITLE
Implement codecov reporting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
           - ruby: "2.7"
           - ruby: "3.0"
             coverage: "yes"
+    env:
+      COVERAGE: ${{ matrix.coverage }}
     steps:
       - uses: actions/checkout@v2
       - name: Install Ruby ${{ matrix.ruby }}
@@ -27,9 +29,5 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-        env:
-          BUNDLE_WITHOUT: release
       - name: Run tests
-        env:
-          COVERAGE: ${{ matrix.coverage }}
         run: bundle exec rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,8 @@ end
 group :release do
   gem 'github_changelog_generator', require: false
 end
+
+group :coverage, optional: ENV['COVERAGE']!='yes' do
+  gem 'simplecov-console', :require => false
+  gem 'codecov', :require => false
+end

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'fakefs', '~> 1.0'
-  s.add_development_dependency 'simplecov'
   s.add_development_dependency 'rake', '~> 13.0'
 
   # Provisioner dependencies - needed for acceptance tests

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,27 @@
-require 'simplecov'
+begin
+  require 'simplecov'
+  require 'simplecov-console'
+  require 'codecov'
+rescue LoadError
+else
+  SimpleCov.start do
+    track_files 'lib/**/*.rb'
+
+    add_filter '/spec'
+
+    enable_coverage :branch
+
+    # do not track vendored files
+    add_filter '/vendor'
+    add_filter '/.vendor'
+  end
+
+  SimpleCov.formatters = [
+    SimpleCov::Formatter::Console,
+    SimpleCov::Formatter::Codecov,
+  ]
+end
+
 require 'beaker'
 require 'fakefs/spec_helpers'
 require 'mocks'


### PR DESCRIPTION
this also updates the gemspec/spec_helper to not depend on simplecov.
Right now we need to pull in the gem on all beaker-* projects because
they load the spec_helper.rb from beaker, which loads simplecov, which
isn't an explicit dependency. This PR cleans this up and also adds
coverage reporting.