### PR TITLE
Fix Platform version string comparison for install_local_package

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -527,7 +527,7 @@ module Unix::Pkg
     case variant
     when /^(fedora|el|redhat|centos)$/
       command_name = 'yum'
-      command_name = 'dnf' if variant == 'fedora' && version > 21
+      command_name = 'dnf' if variant == 'fedora' && version.to_i > 21
       execute("#{command_name} --nogpgcheck localinstall -y #{onhost_package_file}")
     when /^(opensuse|sles)$/
       execute("zypper --non-interactive --no-gpg-checks in #{onhost_package_file}")

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -525,14 +525,9 @@ module Beaker
     describe '#install_local_package' do
       let( :platform      ) { @platform || 'fedora' }
       let( :version       ) { @version  || 6        }
-      let( :platform_mock ) {
-        mock = Object.new
-        allow( mock ).to receive( :to_array ) { [platform, version, '', ''] }
-        mock
-      }
 
       before :each do
-        allow( instance ).to receive( :[] ).with( 'platform' ) { platform_mock }
+        allow( instance ).to receive( :[] ).with( 'platform' ) { Beaker::Platform.new("#{platform}-#{version}-x86_64") }
       end
 
       it 'Fedora 22-39: uses dnf' do
@@ -546,7 +541,6 @@ module Beaker
 
       it 'Fedora 21 uses yum' do
         package_file = 'testing_456.yay'
-        platform_mock = Object.new
         [21].each do |version|
           @version = version
           expect( instance ).to receive( :execute ).with( /^yum.*#{package_file}$/ )
@@ -594,18 +588,13 @@ module Beaker
       let( :tar_file      ) { 'test.tar.gz'         }
       let( :base_dir      ) { '/base/dir/fake'      }
       let( :download_file ) { 'download_file.txt'   }
-      let( :platform_mock ) {
-        mock = Object.new
-        allow( mock ).to receive( :to_array ) { [platform, version, '', ''] }
-        mock
-      }
 
       before :each do
-        allow( instance ).to receive( :[] ).with( 'platform' ) { platform_mock }
+        allow( instance ).to receive( :[] ).with( 'platform' ) {  Beaker::Platform.new("#{platform}-#{version}-x86_64")  }
       end
 
       it 'rejects unsupported platforms' do
-        @platform = 'huawei'
+        @platform = 'cisco_nexus'
         expect {
           instance.uncompress_local_tarball( tar_file, base_dir, download_file )
         }.to raise_error(


### PR DESCRIPTION
The version string from Beaker::Platform was being compared to an integer. 

This was failing on fedora OS with:

```
An error occurred in a `before(:suite)` hook.
Failure/Error: host.install_local_package(package)
ArgumentError:
  comparison of Beaker::Platform with 21 failed
  
# ./.bundle/gems/ruby/2.5.0/bundler/gems/beaker-69705201a73f/lib/beaker/host/unix/pkg.rb:530:in `>'
# ./.bundle/gems/ruby/2.5.0/bundler/gems/beaker-69705201a73f/lib/beaker/host/unix/pkg.rb:530:in `install_local_package'
# ./spec/package/support/install_pdk.rb:34:in `install_local_pdk_package'
# ./spec/package/support/install_pdk.rb:9:in `install_pdk_on'
# ./spec/spec_helper_package.rb:18:in `block (3 levels) in <top (required)>'
# ./spec/spec_helper_package.rb:17:in `each'
# ./spec/spec_helper_package.rb:17:in `block (2 levels) in <top (required)>'
```

Unit tests were mocking out `Beaker::Platform` and returning an integer. This commit updates the tests to return a `Beaker::Platform` object rather than a mock.

The change in test from `huawei` to `cisco_nexus` was so that the initialisation of the `Beaker::Platform` is successful, while still allowing the test case condition to be met.


