### PR TITLE
Add ed25519 as runtime dependency 

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'hocon', '~> 1.0'
   s.add_runtime_dependency 'net-ssh', '>= 5.0'
-  s.add_runtime_dependency 'ed25519' # net-ssh needs this to connect to modern systems
+  s.add_runtime_dependency 'ed25519', '~> 1.0' # net-ssh compatibility with ed25519 keys
   s.add_runtime_dependency 'net-scp', '>= 1.2', '< 4.0'
   s.add_runtime_dependency 'inifile', '~> 3.0'
 

--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'hocon', '~> 1.0'
   s.add_runtime_dependency 'net-ssh', '>= 5.0'
+  s.add_runtime_dependency 'ed25519' # net-ssh needs this to connect to modern systems
   s.add_runtime_dependency 'net-scp', '>= 1.2', '< 4.0'
   s.add_runtime_dependency 'inifile', '~> 3.0'
 


### PR DESCRIPTION
Previously we had this on voxpupuli-acceptance, but it makes more sense
here. See https://github.com/voxpupuli/voxpupuli-acceptance/pull/29