### PR TITLE
Support an extension to tmpfile

### DIFF
--- a/lib/beaker/host/aix/file.rb
+++ b/lib/beaker/host/aix/file.rb
@@ -1,8 +1,8 @@
 module Aix::File
   include Beaker::CommandFactory
 
-  def tmpfile(name = '')
-    execute("rndnum=${RANDOM} && touch /tmp/#{name}.${rndnum} && echo /tmp/#{name}.${rndnum}")
+  def tmpfile(name = '', extension = nil)
+    execute("rndnum=${RANDOM} && touch /tmp/#{name}.${rndnum}#{extension} && echo /tmp/#{name}.${rndnum}#{extension}")
   end
 
   def tmpdir(name = '')

--- a/lib/beaker/host/pswindows/file.rb
+++ b/lib/beaker/host/pswindows/file.rb
@@ -1,7 +1,13 @@
 module PSWindows::File
   include Beaker::CommandFactory
 
-  def tmpfile(_name = '')
+  def tmpfile(_name = '', extension = nil)
+    if extension
+      # TODO: I do not have access to Windows, but the internet suggests this
+      # $newname = [System.IO.Path]::ChangeExtension($filename, "#{extension}") ; MoveItem $filename $newname
+      raise NotImplementedError, 'Passing an extension is not implemented'
+    end
+
     result = exec(powershell('[System.IO.Path]::GetTempFileName()'))
     result.stdout.chomp
   end

--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -1,8 +1,8 @@
 module Unix::File
   include Beaker::CommandFactory
 
-  def tmpfile(name = '')
-    execute("mktemp -t #{name}.XXXXXX")
+  def tmpfile(name = '', extension = nil)
+    execute("mktemp -t #{name}.XXXXXX#{extension}")
   end
 
   def tmpdir(name = '')

--- a/lib/beaker/host/windows/file.rb
+++ b/lib/beaker/host/windows/file.rb
@@ -1,8 +1,8 @@
 module Windows::File
   include Beaker::CommandFactory
 
-  def tmpfile(name = '')
-    execute("cygpath -m $(mktemp -t #{name}.XXXXXX)")
+  def tmpfile(name = '', extension = nil)
+    execute("cygpath -m $(mktemp -t #{name}.XXXXXX#{extension})")
   end
 
   def tmpdir(name = '')


### PR DESCRIPTION
Sometimes tools expect a certain extension or it is just cleaner to have one. This adds an optional parameter which keeps the API compatible.