### PR TITLE
Add Ruby 3.1 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
           - ruby: "2.6"
           - ruby: "2.7"
           - ruby: "3.0"
+          - ruby: "3.1"
             coverage: "yes"
     env:
       COVERAGE: ${{ matrix.coverage }}

--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,5 @@ group :coverage, optional: ENV['COVERAGE']!='yes' do
   gem 'simplecov-console', :require => false
   gem 'codecov', :require => false
 end
+
+gem 'rdoc' if RUBY_VERSION >= '3.1'

--- a/lib/beaker/options/hosts_file_parser.rb
+++ b/lib/beaker/options/hosts_file_parser.rb
@@ -24,7 +24,7 @@ module Beaker
 
           raise "#{hosts_file_path} is not a valid path" unless File.exist?(hosts_file_path)
 
-          YAML.load(ERB.new(File.read(hosts_file_path), nil, '-').result(binding))
+          process_yaml(File.read(hosts_file_path), binding)
         }
         fix_roles_array( host_options )
       end
@@ -42,7 +42,7 @@ module Beaker
         return host_options unless hosts_def_yaml
         error_message = "#{hosts_def_yaml}\nis not a valid YAML string\n\t"
         host_options = self.merge_hosts_yaml( host_options, error_message ) {
-          YAML.load(ERB.new(hosts_def_yaml, nil, '-').result(binding))
+          process_yaml(hosts_def_yaml, binding)
         }
         fix_roles_array( host_options )
       end
@@ -85,6 +85,19 @@ module Beaker
         host_options.merge( loaded_host_options )
       end
 
+      # A helper to parse the YAML file and apply ERB templating
+      #
+      # @param [String] path Path to the file to read
+      # @param [Binding] b The binding to pass to ERB rendering
+      # @api private
+      def self.process_yaml(template, b)
+        erb_obj = if RUBY_VERSION >= '2.7'
+                     ERB.new(template, trim_mode: '-')
+                   else
+                     ERB.new(template, nil, '-')
+                   end
+        YAML.load(erb_obj.result(b))
+      end
     end
   end
 end

--- a/lib/beaker/options/hosts_file_parser.rb
+++ b/lib/beaker/options/hosts_file_parser.rb
@@ -2,6 +2,7 @@ module Beaker
   module Options
     #A set of functions to parse hosts files
     module HostsFileParser
+      PERMITTED_YAML_CLASSES = [Beaker::Options::OptionsHash, Beaker::Platform, Symbol, Time]
 
       # Read the contents of the hosts.cfg into an OptionsHash, merge the 'CONFIG' section into the OptionsHash, return OptionsHash
       # @param [String] hosts_file_path The path to the hosts file
@@ -96,7 +97,11 @@ module Beaker
                    else
                      ERB.new(template, nil, '-')
                    end
-        YAML.load(erb_obj.result(b))
+        if RUBY_VERSION >= '2.6'
+          YAML.safe_load(erb_obj.result(b), permitted_classes: PERMITTED_YAML_CLASSES)
+        else
+          YAML.load(erb_obj.result(b))
+        end
       end
     end
   end

--- a/spec/beaker/cli_spec.rb
+++ b/spec/beaker/cli_spec.rb
@@ -1,5 +1,15 @@
 require 'spec_helper'
 
+def load_yaml_file(path)
+  # Ruby 2.x has no safe_load_file
+  if YAML.respond_to?(:safe_load_file)
+    permitted = [Beaker::Options::OptionsHash, Symbol, RSpec::Mocks::Double, Time]
+    YAML.safe_load_file(path, permitted_classes: permitted, aliases: true)
+  else
+    YAML.load_file(path)
+  end
+end
+
 module Beaker
   describe CLI do
 
@@ -361,7 +371,7 @@ module Beaker
           cli.instance_variable_set(:@hosts, hosts)
 
           preserved_file = cli.preserve_hosts_file
-          hosts_yaml = YAML.load_file(preserved_file)
+          hosts_yaml = load_yaml_file(preserved_file)
           expect(hosts_yaml['CONFIG'][:tests]).to be == []
           expect(hosts_yaml['CONFIG'][:pre_suite]).to be == []
           expect(hosts_yaml['CONFIG'][:post_suite]).to be == []
@@ -428,7 +438,7 @@ module Beaker
             cli.execute!
 
             copied_hosts_file = File.join(File.absolute_path(dir), 'hosts_preserved.yml')
-            expect{ YAML.load_file(copied_hosts_file) }.to_not raise_error
+            expect{ load_yaml_file(copied_hosts_file) }.to_not raise_error
           end
         end
 
@@ -440,7 +450,7 @@ module Beaker
             cli.execute!
 
             copied_hosts_file = File.join(File.absolute_path(dir), 'hosts_preserved.yml')
-            yaml_content = YAML.load_file(copied_hosts_file)
+            yaml_content = load_yaml_file(copied_hosts_file)
             expect( yaml_content['CONFIG']['provision'] ).to be_falsy
           end
         end

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -106,7 +106,7 @@ module Beaker
         pkg = 'sles_package'
         expect( Beaker::Command ).to receive( :new ).with( /^rpmkeys.*nightlies.puppetlabs.com.*/, anything, anything ).and_return('').ordered.once
         expect( Beaker::Command ).to receive(:new).with("zypper --gpg-auto-import-keys se -i --match-exact #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('').ordered.once
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0})).exactly(2).times
+        expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0})).exactly(2).times
         expect( instance.check_for_package(pkg) ).to be === true
       end
       it "checks correctly on opensuse" do
@@ -114,7 +114,7 @@ module Beaker
         pkg = 'sles_package'
         expect( Beaker::Command ).to receive( :new ).with( /^rpmkeys.*nightlies.puppetlabs.com.*/, anything, anything ).and_return('').ordered.once
         expect( Beaker::Command ).to receive(:new).with("zypper --gpg-auto-import-keys se -i --match-exact #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('').ordered.once
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0})).exactly(2).times
+        expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0})).exactly(2).times
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -122,7 +122,7 @@ module Beaker
         @opts = {'platform' => 'fedora-is-me'}
         pkg = 'fedora_package'
         expect( Beaker::Command ).to receive(:new).with("rpm -q #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -131,7 +131,7 @@ module Beaker
           @opts = {'platform' => "#{platform}-is-me"}
           pkg = "#{platform}_package"
           expect( Beaker::Command ).to receive(:new).with("rpm -q #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-          expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
+          expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
           expect( instance.check_for_package(pkg) ).to be === true
         end
       end
@@ -140,7 +140,7 @@ module Beaker
         @opts = {'platform' => 'eos-is-me'}
         pkg = 'eos-package'
         expect( Beaker::Command ).to receive(:new).with("rpm -q #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -148,7 +148,7 @@ module Beaker
         @opts = {'platform' => 'el-is-me'}
         pkg = 'el_package'
         expect( Beaker::Command ).to receive(:new).with("rpm -q #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -156,14 +156,14 @@ module Beaker
         @opts = {'platform' => 'huaweios-is-me'}
         pkg = 'debian_package'
         expect( Beaker::Command ).to receive(:new).with("dpkg -s #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
       it "checks correctly on debian" do
         @opts = {'platform' => 'debian-is-me'}
         pkg = 'debian_package'
         expect( Beaker::Command ).to receive(:new).with("dpkg -s #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -171,7 +171,7 @@ module Beaker
         @opts = {'platform' => 'ubuntu-is-me'}
         pkg = 'ubuntu_package'
         expect( Beaker::Command ).to receive(:new).with("dpkg -s #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -179,7 +179,7 @@ module Beaker
         @opts = {'platform' => 'cumulus-is-me'}
         pkg = 'cumulus_package'
         expect( Beaker::Command ).to receive(:new).with("dpkg -s #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -187,7 +187,7 @@ module Beaker
         @opts = {'platform' => 'solaris-11-is-me'}
         pkg = 'solaris-11_package'
         expect( Beaker::Command ).to receive(:new).with("pkg info #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -195,7 +195,7 @@ module Beaker
         @opts = {'platform' => 'solaris-10-is-me'}
         pkg = 'solaris-10_package'
         expect( Beaker::Command ).to receive(:new).with("pkginfo #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 
@@ -203,7 +203,7 @@ module Beaker
         @opts = {'platform' => 'archlinux-is-me'}
         pkg = 'archlinux_package'
         expect( Beaker::Command ).to receive(:new).with("pacman -Q #{pkg}", [], {:prepend_cmds=>nil, :cmdexe=>false}).and_return('')
-        expect( instance ).to receive(:exec).with('', :accept_all_exit_codes => true).and_return(generate_result("hello", {:exit_code => 0}))
+        expect( instance ).to receive(:exec).with('', {:accept_all_exit_codes => true}).and_return(generate_result("hello", {:exit_code => 0}))
         expect( instance.check_for_package(pkg) ).to be === true
       end
 

--- a/spec/beaker/options/hosts_file_parser_spec.rb
+++ b/spec/beaker/options/hosts_file_parser_spec.rb
@@ -66,9 +66,10 @@ module Beaker
           expect( host_options ).to be === parser.new_host_options
         end
 
-        it 'passes a YAML.load call through to #merge_hosts_yaml' do
+        it 'passes a process_yaml call through to #merge_hosts_yaml' do
           yaml_string = 'not actually yaml, but that wont matter'
-          expect( YAML ).to receive( :load ).with( yaml_string )
+          expect(described_class).to receive(:process_yaml).with(yaml_string, instance_of(Binding))
+
           parser.parse_hosts_string( yaml_string )
         end
       end

--- a/spec/beaker/platform_spec.rb
+++ b/spec/beaker/platform_spec.rb
@@ -150,7 +150,14 @@ module Beaker
         @name = 'ubuntu-14.04-x86_64'
       end
 
-      let(:round_tripped) { YAML.load(YAML.dump(platform)) }
+      let(:round_tripped) do
+        # Ruby 2 has no unsafe_load
+        if YAML.respond_to?(:unsafe_load)
+          YAML.unsafe_load(YAML.dump(platform))
+        else
+          YAML.load(YAML.dump(platform))
+        end
+      end
 
       [:variant, :arch, :version, :codename].each do |field|
         it "deserializes the '#{field}' field" do


### PR DESCRIPTION
In Ruby 3.1 using trim_mode must be passed as a keyword argument or a deprecation warning is shown. However, that is only possible on Ruby 2.7 or newer.