### PR TITLE
Drop pry dependency

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -32,9 +32,6 @@ Gem::Specification.new do |s|
   # Run time dependencies
   s.add_runtime_dependency 'minitest', '~> 5.4'
   s.add_runtime_dependency 'minitar', '~> 0.6'
-  s.add_runtime_dependency 'pry-byebug', '~> 3.9'
-  # pry-byebug can have issues with native readline libs so add rb-readline
-  s.add_runtime_dependency 'rb-readline', '~> 0.5.3'
   s.add_runtime_dependency 'rexml'
 
   s.add_runtime_dependency 'hocon', '~> 1.0'

--- a/docs/how_to/debug_beaker_tests.md
+++ b/docs/how_to/debug_beaker_tests.md
@@ -1,6 +1,6 @@
 # Debug beaker tests
 
-beaker includes [pry-byebug](https://github.com/deivid-rodriguez/pry-byebug), a gem that combines two powerful related tools: pry and byebug
+beaker can use [pry-byebug](https://github.com/deivid-rodriguez/pry-byebug), a gem that combines two powerful related tools: pry and byebug. It falls back to [debug](https://github.com/ruby/debug) if pry is unavailable.
 
 ### What is Pry?
 
@@ -15,6 +15,10 @@ There are several ways to have your tests break and enter debugging:
  1. [Add a breakpoint to your test file](#add-a-breakpoint-to-your-test-file)
  2. [Use the --debug-errors option](#use-the---debug-errors-option)
  3. [Defining external breakpoints with byebug](#defining-external-breakpoints-with-byebug)
+
+### What is debug?
+
+[debug](https://github.com/ruby/debug) is the new debugger bundled since Ruby 3.1.
 
 ## Add a breakpoint to your test file
 
@@ -232,7 +236,7 @@ Simply `exit` the console.
 
 ## Use the --debug-errors option
 
-You can run beaker and pass the option `--debug-errors` to have beaker enter the pry console if or when a test error occurs. This is useful for transient/intermittent errors where you may need to run the test a large number of times before seeing the failure. It's also useful to keep your hosts at the state where error occurred, as the test's teardown will not (yet) have executed.
+You can run beaker and pass the option `--debug-errors` to have beaker enter the pry or debug console if or when a test error occurs. This is useful for transient/intermittent errors where you may need to run the test a large number of times before seeing the failure. It's also useful to keep your hosts at the state where error occurred, as the test's teardown will not (yet) have executed.
 
 ### Example
 
@@ -249,10 +253,10 @@ Consider this example test case _test.rb_, which is going to fail:
 
 You can run this test using `beaker -t test.rb` or (to use the `run` subcommand and just run the test and bypass host provisioning etc) `beaker run -t test.rb`. It fails.
 
-Now try `beaker run -t test.rb --debug-errors` This will enter a pry console when the failure occurs.
+Now try `beaker run -t test.rb --debug-errors` This will enter a pry or debug console when the failure occurs.
 
     * Assert expected matches actual
-      Exception raised during step execution and debug-errors option is set, entering pry. Exception was: #<Minitest::Assertion: This product is faulty.
+      Exception raised during step execution and debug-errors option is set, entering pry or debug. Exception was: #<Minitest::Assertion: This product is faulty.
        Expected: 3
         Actual: 2>
       HINT: Use the pry 'backtrace' and 'up' commands to navigate to the test code

--- a/lib/beaker.rb
+++ b/lib/beaker.rb
@@ -38,11 +38,4 @@ module Beaker
 
   # MiniTest, for including MiniTest::Assertions
   require 'minitest/test'
-
-  # Add pry support when available
-  begin
-    require 'pry'
-  rescue LoadError
-    # do nothing
-  end
 end

--- a/lib/beaker/dsl/structure.rb
+++ b/lib/beaker/dsl/structure.rb
@@ -31,7 +31,6 @@ module Beaker
     #     end
     #
     module Structure
-      require 'pry'
       # Provides a method to help structure tests into coherent steps.
       # @param [String] step_name The name of the step to be logged.
       # @param [Proc] block The actions to be performed in this step.
@@ -45,9 +44,22 @@ module Beaker
             end
           rescue Exception => e
             if(@options.has_key?(:debug_errors) && @options[:debug_errors] == true)
-              logger.info("Exception raised during step execution and debug-errors option is set, entering pry. Exception was: #{e.inspect}")
-              logger.info("HINT: Use the pry 'backtrace' and 'up' commands to navigate to the test code")
-              binding.pry
+              begin
+                require 'pry'
+              rescue LoadError
+                begin
+                  require 'debug'
+                rescue LoadError
+                  logger.exception('Unable to load pry and debug while debug_errors was true')
+                else
+                  logger.info("Exception raised during step execution and debug-errors option is set, entering debug. Exception was: #{e.inspect}")
+                  binding.break
+                end
+              else
+                logger.info("Exception raised during step execution and debug-errors option is set, entering pry. Exception was: #{e.inspect}")
+                logger.info("HINT: Use the pry 'backtrace' and 'up' commands to navigate to the test code")
+                binding.pry
+              end
             end
             raise e
           end

--- a/spec/beaker/dsl/structure_spec.rb
+++ b/spec/beaker/dsl/structure_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'readline'
 
 class ClassMixedWithDSLStructure
   include Beaker::DSL::Structure


### PR DESCRIPTION
Ruby 3.1 bundles debug.gem which has similar capabilities. This reduces the dependencies that beaker always pulls in.