### PR TITLE
(maint) Remove /etc/environment file for ubuntu2204

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -306,7 +306,7 @@ module Unix::Exec
       directory = tmpdir()
       exec(Beaker::Command.new("echo 'PermitUserEnvironment yes' | cat - /etc/ssh/sshd_config > #{directory}/sshd_config.permit"))
       exec(Beaker::Command.new("mv #{directory}/sshd_config.permit /etc/ssh/sshd_config"))
-      exec(Beaker::Command.new("echo '' >/etc/environment")) if self['platform'] =~ /ubuntu-20.04/
+      exec(Beaker::Command.new("echo '' >/etc/environment")) if self['platform'] =~ /ubuntu-2(0|2).04/
     when /(free|open)bsd/
       exec(Beaker::Command.new("sudo perl -pi -e 's/^#?PermitUserEnvironment no/PermitUserEnvironment yes/' /etc/ssh/sshd_config"), {:pty => true} )
     else


### PR DESCRIPTION
Clear out the environment file for ubuntu 2204 so ~/.ssh/environment can be used.