### PR TITLE
Add support for Win32-OpenSSH

### DIFF
--- a/lib/beaker/host/windows.rb
+++ b/lib/beaker/host/windows.rb
@@ -38,8 +38,14 @@ module Windows
       return @ssh_server if @ssh_server
       @ssh_server = :openssh
       status = execute('cmd.exe /c sc query BvSshServer', :accept_all_exit_codes => true)
-      @ssh_server = :bitvise if status =~ /4  RUNNING/
-      logger.debug("windows.rb:determine_ssh_server: determined ssh server: '#{@ssh_server}'")
+      if status =~ /4  RUNNING/
+        @ssh_server = :bitvise
+      else
+        status = execute('cmd.exe /c sc qc sshd', :accept_all_exit_codes => true)
+        if status =~ /C:\\Windows\\System32\\OpenSSH\\sshd\.exe/
+          @ssh_server = :win32_openssh
+        end
+      end
       @ssh_server
     end
 

--- a/lib/beaker/host/windows/file.rb
+++ b/lib/beaker/host/windows/file.rb
@@ -59,9 +59,11 @@ module Windows::File
     case determine_ssh_server
     when :bitvise
       # swap out separators
-      network_path = path.gsub('\\', scp_separator)
+      path.gsub('\\', scp_separator)
     when :openssh
       path
+    when :win32_openssh
+      path.gsub('\\', '/')
     else
       raise ArgumentError, "windows/file.rb:scp_path: ssh server not recognized: '#{determine_ssh_server}'"
     end

--- a/lib/beaker/host/windows/file.rb
+++ b/lib/beaker/host/windows/file.rb
@@ -63,7 +63,7 @@ module Windows::File
     when :openssh
       path
     else
-      raise ArgumentError("windows/file.rb:scp_path: ssh server not recognized: '#{determine_ssh_server}'")
+      raise ArgumentError, "windows/file.rb:scp_path: ssh server not recognized: '#{determine_ssh_server}'"
     end
   end
 

--- a/spec/beaker/host/windows/file_spec.rb
+++ b/spec/beaker/host/windows/file_spec.rb
@@ -71,6 +71,11 @@ module Beaker
         expect(host.scp_path(path)).to eq('C:\Windows')
       end
 
+      it 'replace backslashes with forward slashes when using Win32-OpenSSH' do
+        allow(host).to receive(:determine_ssh_server).and_return(:win32_openssh)
+        expect(host.scp_path(path)).to eq('C:/Windows')
+      end
+
       it 'raises if the server can not be recognized' do
         allow(host).to receive(:determine_ssh_server).and_return(:unknown)
         expect {

--- a/spec/beaker/host/windows/file_spec.rb
+++ b/spec/beaker/host/windows/file_spec.rb
@@ -51,5 +51,32 @@ module Beaker
         host.ls_ld( path )
       end
     end
+
+    describe "#scp_to" do
+      let(:path) { 'C:\Windows' }
+
+      it 'replaces backslashes with ??? when using BitVise and cmd' do
+        allow(host).to receive(:determine_ssh_server).and_return(:bitvise)
+        expect(host.scp_path(path)).to eq('C:\Windows')
+      end
+
+      it 'replaces backslashes with forward slashes when using BitVise and powershell' do
+        host = make_host('name', platform: 'windows', is_cygwin: false)
+        allow(host).to receive(:determine_ssh_server).and_return(:bitvise)
+        expect(host.scp_path(path)).to eq('C:/Windows')
+      end
+
+      it 'leaves backslashes as is when using cygwin' do
+        allow(host).to receive(:determine_ssh_server).and_return(:openssh)
+        expect(host.scp_path(path)).to eq('C:\Windows')
+      end
+
+      it 'raises if the server can not be recognized' do
+        allow(host).to receive(:determine_ssh_server).and_return(:unknown)
+        expect {
+          host.scp_path(path)
+        }.to raise_error(ArgumentError, "windows/file.rb:scp_path: ssh server not recognized: 'unknown'")
+      end
+    end
   end
 end


### PR DESCRIPTION
Newer versions of Windows ship with Win32-OpenSSH (see https://github.com/PowerShell/openssh-portable) This PR makes it possible to detect when that implementation is used (based on the binary path of the `sshd` service) and it converts backslashes to forward slashes, such as when calling `scp_to`. This is similar to the work that was done to support BitVise and powershell (PSWindows)