### PR TITLE
Create ~/.ssh on Windows if it doesn't exist

### DIFF
--- a/lib/beaker/host/windows/exec.rb
+++ b/lib/beaker/host/windows/exec.rb
@@ -120,10 +120,16 @@ module Windows::Exec
   end
 
   # Create the provided directory structure on the host
-  # @param [String] dir The directory structure to create on the host
+  # @param [String,Pathname] dir The directory structure to create on the host
   # @return [Boolean] True, if directory construction succeeded, otherwise False
-  def mkdir_p dir
-    cmd = "mkdir -p \"#{dir}\""
+  def mkdir_p(dir)
+    # single or double quotes will disable ~ expansion, so only quote if we have to
+    str = dir.to_s
+    cmd = if str.start_with?('~') && !str.include?(' ')
+            "mkdir -p #{str}"
+          else
+            "mkdir -p \"#{str}\""
+          end
     result = exec(Beaker::Command.new(cmd), :acceptable_exit_codes => [0, 1])
     result.exit_code == 0
   end

--- a/spec/beaker/host/windows/exec_spec.rb
+++ b/spec/beaker/host/windows/exec_spec.rb
@@ -96,5 +96,35 @@ module Beaker
          expect( instance.mv(origin, destination, false) ).to be === 0
       end
     end
+
+    context 'mkdir_p' do
+      let(:path) { '~/.ssh' }
+      let(:result) do
+        result = Beaker::Result.new(nil, '')
+        result.exit_code = 0
+        result
+      end
+
+      it 'accepts Pathname arguments' do
+        expect( instance ).to receive(:exec).with(having_attributes(command: "mkdir -p #{path}"), anything).and_return(result)
+        expect(instance.mkdir_p(Pathname.new(path))).to eq(true)
+      end
+
+      it 'omits quotes if the path starts with ~ and does not contain spaces' do
+        expect( instance ).to receive(:exec).with(having_attributes(command: "mkdir -p #{path}"), anything).and_return(result)
+        expect(instance.mkdir_p(path)).to eq(true)
+      end
+
+      it 'double quotes paths containing spaces' do
+        expect( instance ).to receive(:exec).with(having_attributes(command: "mkdir -p \"~/.foo bar\""), anything).and_return(result)
+        expect(instance.mkdir_p("~/.foo bar")).to eq(true)
+      end
+
+      it 'returns false if the command failed' do
+        result.exit_code = 1
+        expect( instance ).to receive(:exec).with(having_attributes(command: "mkdir -p #{path}"), anything).and_return(result)
+        expect(instance.mkdir_p(path)).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
Beaker executed `mkdir -p "~/.ssh"` on Windows hosts as part of the prebuilt
steps sequence. However, when using cygwin bash, the double quotes behave like
single quotes, disabling tilde expansion:

   $ realpath "\~/.ssh"
   /home/Administrator/\~/.ssh

So '~' was a directory containing the '.ssh' directory. This was never noticed
because all of our VM templates already have the expected ~/.ssh directory. But
if the directory doesn't exist, then later steps would fail trying to write to
~/.ssh/environment.

This commit changes beaker behavior in the case that the path starts with tilde
and does not contain a space, so it's safe to not quote the path.

See commit 54b35b7603d25f4b38d11d0173ecd489ee96cad4 which double quoted unix &
windows, which caused a regression that was fixed in 9288623e6e95e5b144d565b2206aad994d15bdcb.