### PR TITLE
Use the new scheme for agent versions >= 6.28 and < 7

### DIFF
--- a/lib/beaker/host/mac/pkg.rb
+++ b/lib/beaker/host/mac/pkg.rb
@@ -121,7 +121,9 @@ module Mac::Pkg
 
     # macOS puppet-agent tarballs haven't always included arch
     agent_version = opts[:puppet_agent_version]
-    download_file = if agent_version && (agent_version.to_f < 6.28 || agent_version.to_f < 7.18)
+    agent_version_f = agent_version&.to_f
+
+    download_file = if agent_version_f.nil? || (agent_version_f < 6.28 || (agent_version_f >= 7.0 && agent_version_f < 7.18))
                       "puppet-agent-#{variant}-#{version}.tar.gz"
                     else
                       "puppet-agent-#{variant}-#{version}-#{arch}.tar.gz"

--- a/spec/beaker/host/mac_spec.rb
+++ b/spec/beaker/host/mac_spec.rb
@@ -82,5 +82,32 @@ module Mac
         expect( release_path_end ).to be === "apple/PC8"
       end
     end
+
+    describe '#pe_puppet_agent_promoted_package_info' do
+      before :each do
+        @platform = "osx-10.15-x86_64"
+      end
+
+      it "uses the old scheme if the version is omitted" do
+        _, _, download_file = host.pe_puppet_agent_promoted_package_info('pa_collection')
+
+        expect(download_file).to eq('puppet-agent-osx-10.15.tar.gz')
+      end
+
+      {
+        '5.5.22' => 'puppet-agent-osx-10.15.tar.gz',
+        '6.27.0' => 'puppet-agent-osx-10.15.tar.gz',
+        '6.28.0' => 'puppet-agent-osx-10.15-x86_64.tar.gz',
+        '7.0.0'  => 'puppet-agent-osx-10.15.tar.gz',
+        '7.18.0' => 'puppet-agent-osx-10.15-x86_64.tar.gz',
+        '8.0.0'  => 'puppet-agent-osx-10.15-x86_64.tar.gz',
+      }.each_pair do |version, expected|
+        it "returns #{expected} for puppet-agent #{version}" do
+          _, _, download_file = host.pe_puppet_agent_promoted_package_info('pa_collection', puppet_agent_version: version)
+
+          expect(download_file).to eq(expected)
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Commit 0008b7ffd3b0bd7891a5ddbf1bb58898b542406d incorrectly returned the old
scheme for agent version 6.28.0, since 6.18 < 7.18. It also incorrectly returned
the new scheme if the puppet_agent_version was omitted.

It now returns the new scheme for versions in the range >= 6.18 to < 7.0, and
returns the old scheme if the version is omitted.