### PR TITLE
(maint) StringInclude Rubocop corrections

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -214,7 +214,7 @@ namespace :history do
     Dir.chdir( File.expand_path(File.dirname(__FILE__)) )
     output = `bundle exec ruby history.rb .`
     puts output
-    if !/success/.match?(output)
+    if !output.include?('success')
       raise "History generation failed"
     end
     Dir.chdir( original_dir )

--- a/acceptance/fixtures/module/Rakefile
+++ b/acceptance/fixtures/module/Rakefile
@@ -10,7 +10,7 @@ task :validate do
     sh "puppet parser validate --noop #{manifest}"
   end
   Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
-    sh "ruby -c #{ruby_file}" unless /spec\/fixtures/.match?(ruby_file)
+    sh "ruby -c #{ruby_file}" unless ruby_file.include?('spec/fixtures')
   end
   Dir['templates/**/*.erb'].each do |template|
     sh "erb -P -x -T '-' #{template} | ruby -c"

--- a/acceptance/tests/base/dsl/helpers/host_helpers/create_remote_file_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/create_remote_file_test.rb
@@ -192,7 +192,7 @@ test_name "dsl::helpers::host_helpers #create_remote_file" do
             rsync_package = "rsync"
             # solaris-10 uses OpenCSW pkgutil, which prepends "CSW" to its provided packages
             # TODO: fix this with BKR-1502
-            rsync_package = "CSWrsync" if /solaris-10/.match?(host['platform'])
+            rsync_package = "CSWrsync" if host['platform'].include?('solaris-10')
             host.uninstall_package rsync_package
           end
           host.delete(:rsync_installed)

--- a/acceptance/tests/base/dsl/helpers/host_helpers/rsync_to_test.rb
+++ b/acceptance/tests/base/dsl/helpers/host_helpers/rsync_to_test.rb
@@ -73,7 +73,7 @@ test_name "dsl::helpers::host_helpers #rsync_to" do
             rsync_package = "rsync"
             # solaris-10 uses OpenCSW pkgutil, which prepends "CSW" to its provided packages
             # TODO: fix this with BKR-1502
-            rsync_package = "CSWrsync" if /solaris-10/.match?(host['platform'])
+            rsync_package = "CSWrsync" if host['platform'].include?('solaris-10')
             host.uninstall_package rsync_package
           else
             host[:rsync_installed] = false
@@ -175,7 +175,7 @@ test_name "dsl::helpers::host_helpers #rsync_to" do
             rsync_package = "rsync"
             # solaris-10 uses OpenCSW pkgutil, which prepends "CSW" to its provided packages
             # TODO: fix this with BKR-1502
-            rsync_package = "CSWrsync" if /solaris-10/.match?(host['platform'])
+            rsync_package = "CSWrsync" if host['platform'].include?('solaris-10')
             host.uninstall_package rsync_package
           end
           host.delete(:rsync_installed)

--- a/acceptance/tests/base/host/packages.rb
+++ b/acceptance/tests/base/host/packages.rb
@@ -3,23 +3,23 @@ confine :except, :platform => %w(osx)
 
 def get_host_pkg(host)
   case
-    when /sles-10/.match?(host['platform'])
+    when host['platform'].include?('sles-10')
       Beaker::HostPrebuiltSteps::SLES10_PACKAGES
     when /opensuse|sles-/.match?(host['platform'])
       Beaker::HostPrebuiltSteps::SLES_PACKAGES
-    when /debian/.match?(host['platform'])
+    when host['platform'].include?('debian')
       Beaker::HostPrebuiltSteps::DEBIAN_PACKAGES
-    when /cumulus/.match?(host['platform'])
+    when host['platform'].include?('cumulus')
       Beaker::HostPrebuiltSteps::CUMULUS_PACKAGES
     when (host['platform'].include?('windows') and host.is_cygwin?)
       Beaker::HostPrebuiltSteps::WINDOWS_PACKAGES
     when (host['platform'].include?('windows') and not host.is_cygwin?)
       Beaker::HostPrebuiltSteps::PSWINDOWS_PACKAGES
-    when /freebsd/.match?(host['platform'])
+    when host['platform'].include?('freebsd')
       Beaker::HostPrebuiltSteps::FREEBSD_PACKAGES
-    when /openbsd/.match?(host['platform'])
+    when host['platform'].include?('openbsd')
       Beaker::HostPrebuiltSteps::OPENBSD_PACKAGES
-    when /solaris-10/.match?(host['platform'])
+    when host['platform'].include?('solaris-10')
       Beaker::HostPrebuiltSteps::SOLARIS10_PACKAGES
     else
       Beaker::HostPrebuiltSteps::UNIX_PACKAGES
@@ -50,12 +50,12 @@ hosts.each do |host|
   # this works on Windows as well, althought it pulls in
   # a lot of dependencies.
   # skipping this test for windows since it requires a restart
-  next if /windows/.match?(host['platform'])
+  next if host['platform'].include?('windows')
   package = 'zsh'
-  package = 'CSWzsh' if /solaris-10/.match?(host['platform'])
+  package = 'CSWzsh' if host['platform'].include?('solaris-10')
   package = 'git' if /opensuse|sles/.match?(host['platform'])
 
-  if /solaris-11/.match?(host['platform'])
+  if host['platform'].include?('solaris-11')
     logger.debug("#{package} should be uninstalled on #{host}")
     host.uninstall_package(package)
     assert_equal(false, host.check_for_package(package), "'#{package}' should not be installed")
@@ -71,10 +71,10 @@ hosts.each do |host|
   assert(host.check_for_package(package), "'#{package}' should be installed")
 
   # windows does not support uninstall_package
-  unless /windows/.match?(host['platform'])
+  unless host['platform'].include?('windows')
     logger.debug("#{package} should be uninstalled on #{host}")
     host.uninstall_package(package)
-    if /debian/.match?(host['platform'])
+    if host['platform'].include?('debian')
       assert_equal(false, host.check_for_command(package), "'#{package}' should not be installed or available")
     else
       assert_equal(false, host.check_for_package(package), "'#{package}' should not be installed")

--- a/acceptance/tests/base/host/packages.rb
+++ b/acceptance/tests/base/host/packages.rb
@@ -2,27 +2,25 @@ test_name 'confirm packages on hosts behave correctly'
 confine :except, :platform => %w(osx)
 
 def get_host_pkg(host)
-  case
-    when host['platform'].include?('sles-10')
-      Beaker::HostPrebuiltSteps::SLES10_PACKAGES
-    when /opensuse|sles-/.match?(host['platform'])
-      Beaker::HostPrebuiltSteps::SLES_PACKAGES
-    when host['platform'].include?('debian')
-      Beaker::HostPrebuiltSteps::DEBIAN_PACKAGES
-    when host['platform'].include?('cumulus')
-      Beaker::HostPrebuiltSteps::CUMULUS_PACKAGES
-    when (host['platform'].include?('windows') and host.is_cygwin?)
-      Beaker::HostPrebuiltSteps::WINDOWS_PACKAGES
-    when (host['platform'].include?('windows') and not host.is_cygwin?)
-      Beaker::HostPrebuiltSteps::PSWINDOWS_PACKAGES
-    when host['platform'].include?('freebsd')
-      Beaker::HostPrebuiltSteps::FREEBSD_PACKAGES
-    when host['platform'].include?('openbsd')
-      Beaker::HostPrebuiltSteps::OPENBSD_PACKAGES
-    when host['platform'].include?('solaris-10')
-      Beaker::HostPrebuiltSteps::SOLARIS10_PACKAGES
-    else
-      Beaker::HostPrebuiltSteps::UNIX_PACKAGES
+  case host['platform']
+  when /sles-10/
+    Beaker::HostPrebuiltSteps::SLES10_PACKAGES
+  when /opensuse|sles-/
+    Beaker::HostPrebuiltSteps::SLES_PACKAGES
+  when /debian/
+    Beaker::HostPrebuiltSteps::DEBIAN_PACKAGES
+  when /cumulus/
+    Beaker::HostPrebuiltSteps::CUMULUS_PACKAGES
+  when /windows/
+    host.is_cygwin? ? Beaker::HostPrebuiltSteps::WINDOWS_PACKAGES : Beaker::HostPrebuiltSteps::PSWINDOWS_PACKAGES
+  when /freebsd/
+    Beaker::HostPrebuiltSteps::FREEBSD_PACKAGES
+  when /openbsd/
+    Beaker::HostPrebuiltSteps::OPENBSD_PACKAGES
+  when /solaris-10/
+    Beaker::HostPrebuiltSteps::SOLARIS10_PACKAGES
+  else
+    Beaker::HostPrebuiltSteps::UNIX_PACKAGES
   end
 
 end

--- a/acceptance/tests/base/host/packages_unix.rb
+++ b/acceptance/tests/base/host/packages_unix.rb
@@ -18,7 +18,7 @@ end
 def pkg_file(host, pkg_name)
   if /debian|ubuntu/.match?(host['platform'])
     "/etc/apt/sources.list.d/#{pkg_name}.list"
-  elsif /el/.match?(host['platform'])
+  elsif host['platform'].include?('el')
     "/etc/yum.repos.d/#{pkg_name}.repo"
   else
     nil
@@ -45,7 +45,7 @@ end
 step '#deploy_yum_repo : deploy puppet-server nightly repo'
 hosts.each do |host|
 
-  if /el/.match?(host['platform'])
+  if host['platform'].include?('el')
     clean_file(host, pkg_name)
     host.deploy_yum_repo(pkg_fixtures, pkg_name, 'latest')
     assert(host.file_exist?(pkg_file(host, pkg_name)), 'yum file should exist')

--- a/acceptance/tests/install/from_file.rb
+++ b/acceptance/tests/install/from_file.rb
@@ -4,7 +4,7 @@ confine :except, :platform => /^windows|osx/
 
 step 'install arbitrary msi via url' do
   hosts.each do |host|
-    if /win/.match?(host['platform'])
+    if host['platform'].include?('win')
       # this should be implemented at the host/win/pkg.rb level someday
       generic_install_msi_on(host, 'https://releases.hashicorp.com/vagrant/1.8.4/vagrant_1.8.4.msi', {}, {:debug => true})
     end
@@ -13,7 +13,7 @@ end
 
 step 'install arbitrary dmg via url' do
   hosts.each do |host|
-    if /osx/.match?(host['platform'])
+    if host['platform'].include?('osx')
       host.generic_install_dmg('https://releases.hashicorp.com/vagrant/1.8.4/vagrant_1.8.4.dmg', 'Vagrant', 'Vagrant.pkg')
     end
   end

--- a/lib/beaker/cli.rb
+++ b/lib/beaker/cli.rb
@@ -118,7 +118,7 @@ module Beaker
         rescue => e
           #post acceptance on failure
           #run post-suite if we are in fail-slow mode
-          if /slow/.match?(@options[:fail_mode].to_s)
+          if @options[:fail_mode].to_s.include?('slow')
             run_suite(:post_suite)
             @perf.print_perf_info if defined? @perf
           end

--- a/lib/beaker/command.rb
+++ b/lib/beaker/command.rb
@@ -76,7 +76,7 @@ module Beaker
       append_commands = host.append_commands( cmd, ac, :cmd_exe => @cmdexe )
 
       # This will cause things like `puppet -t -v agent` which is maybe bad.
-      if host[:platform].include?('cisco_ios_xr')
+      if host[:platform]&.include?('cisco_ios_xr')
         cmd_line_array = [prepend_commands, env_string, cmd, options_string, args_string, append_commands]
       else
         cmd_line_array = [env_string, prepend_commands, cmd, options_string, args_string, append_commands]

--- a/lib/beaker/command.rb
+++ b/lib/beaker/command.rb
@@ -76,7 +76,7 @@ module Beaker
       append_commands = host.append_commands( cmd, ac, :cmd_exe => @cmdexe )
 
       # This will cause things like `puppet -t -v agent` which is maybe bad.
-      if /cisco_ios_xr/.match?(host[:platform])
+      if host[:platform].include?('cisco_ios_xr')
         cmd_line_array = [prepend_commands, env_string, cmd, options_string, args_string, append_commands]
       else
         cmd_line_array = [env_string, prepend_commands, cmd, options_string, args_string, append_commands]

--- a/lib/beaker/dsl/helpers/host_helpers.rb
+++ b/lib/beaker/dsl/helpers/host_helpers.rb
@@ -491,7 +491,7 @@ module Beaker
         #
         # @return [Boolean] Whether the file exists on the host (using `test -f`)
         def file_exists_on(host, file_path)
-          if /windows/.match?(host['platform'])
+          if host[:platform].include?('windows')
             command = %(Test-Path #{file_path})
 
             if file_path.include?(':')
@@ -516,7 +516,7 @@ module Beaker
         #
         # @return [Boolean] Whether the directory exists on the host (using `test -d`)
         def directory_exists_on(host, dir_path)
-          if /windows/.match?(host['platform'])
+          if host[:platform].include?('windows')
             dir_path = "#{dir_path}\\" unless (dir_path[-1].chr == '\\')
 
             command = Command.new(%{IF exist "#{dir_path}" ( exit 0 ) ELSE ( exit 1 )}, [], { :cmdexe => true })
@@ -535,7 +535,7 @@ module Beaker
         # @return [Boolean] Whether the symlink exists on the host (using `test -L`)
         def link_exists_on(host, link_path)
           # Links are weird on windows, fall back to seeing if the file exists
-          return file_exists_on(host, link_path) if /windows/.match?(host['platform'])
+          return file_exists_on(host, link_path) if host[:platform].include?('windows')
 
           return on(host, Command.new(%(test -L "#{link_path}"), accept_all_exit_codes: true)).exit_code.zero?
         end
@@ -551,7 +551,7 @@ module Beaker
 
           split_path = win_ads_path(file_path)
           if file_exists_on(host, split_path[:path])
-            if /windows/.match?(host['platform'])
+            if host[:platform].include?('windows')
               file_path.tr!('/', '\\')
 
               command = %{Get-Content -Raw -Path #{file_path}}

--- a/lib/beaker/dsl/helpers/web_helpers.rb
+++ b/lib/beaker/dsl/helpers/web_helpers.rb
@@ -92,7 +92,7 @@ module Beaker
         # @!visibility private
         def fetch_http_dir(url, dst_dir)
           logger.notify "fetch_http_dir (url: #{url}, dst_dir #{dst_dir})"
-          if !/\//.match?(url[-1, 1])
+          if !url.end_with?('/')
             url += '/'
           end
           url = URI.parse(url)

--- a/lib/beaker/dsl/structure.rb
+++ b/lib/beaker/dsl/structure.rb
@@ -314,7 +314,7 @@ module Beaker
       rescue Beaker::DSL::Outcomes::SkipTest => e
         # I don't like this much, but adding options to confine is a breaking change
         # to the DSL that would involve a major version bump
-        if !/No suitable hosts found/.match?(e.message)
+        if !e.message.include?('No suitable hosts found')
           # a skip generated from the provided block, pass it up the chain
           raise e
         end

--- a/lib/beaker/host/cisco.rb
+++ b/lib/beaker/host/cisco.rb
@@ -34,7 +34,7 @@ module Cisco
     #
     # @return nil
     def scp_post_operations(scp_file_actual, scp_file_target)
-      if /cisco_nexus/.match?(self[:platform])
+      if self[:platform].include?('cisco_nexus')
         execute( "mv #{scp_file_actual} #{scp_file_target}" )
       end
       nil
@@ -47,7 +47,7 @@ module Cisco
     # @return [String] path, changed if needed due to host
     #   constraints
     def scp_path(path)
-      if /cisco_nexus/.match?(self[:platform])
+      if self[:platform].include?('cisco_nexus')
         @home_dir ||= execute( 'pwd' )
         answer = "#{@home_dir}/#{File.basename( path )}"
         answer << '/' if /\/$/.match?(path)
@@ -83,7 +83,7 @@ module Cisco
     # @return [String] Command string as needed for this host
     def prepend_commands(command = '', user_pc = '', _opts = {})
       return user_pc unless command.index('vsh').nil?
-      if /cisco_nexus/.match?(self[:platform])
+      if self[:platform].include?('cisco_nexus')
         return user_pc unless command.index('ntpdate').nil?
       end
 
@@ -128,13 +128,13 @@ module Cisco
       env_array = self.environment_variable_string_pair_array( env )
       environment_string = env_array.join(' ')
 
-      if /cisco_nexus/.match?(self[:platform])
+      if self[:platform].include?('cisco_nexus')
         prestring << " export"
       else
         prestring << " env"
       end
       environment_string = "#{prestring} #{environment_string}"
-      environment_string << ';' if /export/.match?(prestring)
+      environment_string << ';' if prestring.include?('export')
       environment_string
     end
 
@@ -145,7 +145,7 @@ module Cisco
     #   this will be raised with the appropriate message
     def validate_setup
       msg = nil
-      if /cisco_nexus/.match?(self[:platform])
+      if self[:platform].include?('cisco_nexus')
         if !self[:vrf]
           msg = 'Cisco Nexus hosts must be provided with a :vrf value.'
         end
@@ -153,7 +153,7 @@ module Cisco
           msg = 'Cisco hosts must be provided with a :user value'
         end
       end
-      if /cisco_ios_xr/.match?(self[:platform])
+      if self[:platform].include?('cisco_ios_xr')
         if !self[:user]
           msg = 'Cisco hosts must be provided with a :user value'
         end

--- a/lib/beaker/host/pswindows/pkg.rb
+++ b/lib/beaker/host/pswindows/pkg.rb
@@ -37,7 +37,7 @@ module PSWindows::Pkg
     arch = nil
     execute("wmic os get osarchitecture", :accept_all_exit_codes => true) do |result|
       arch = if result.exit_code == 0
-        /64/.match?(result.stdout) ? '64' : '32'
+        result.stdout.include?('64') ? '64' : '32'
       else
         identify_windows_architecture_from_os_name_for_win2003
       end
@@ -49,7 +49,7 @@ module PSWindows::Pkg
   def identify_windows_architecture_from_os_name_for_win2003
     arch = nil
     execute("wmic os get name", :accept_all_exit_codes => true) do |result|
-      arch = /64/.match?(result.stdout) ? '64' : '32'
+      arch = result.stdout.include?('64') ? '64' : '32'
     end
     arch
   end

--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -400,7 +400,7 @@ module Unix::Exec
       arch = $3
       arch = 'amd64' if ['x64', 'x86_64'].include?(arch)
       add_env_var('PKG_PATH', "http://ftp.openbsd.org/pub/OpenBSD/#{version}/packages/#{arch}/")
-    elsif /solaris-10/.match?(self['platform'])
+    elsif self['platform'].include?('solaris-10')
       add_env_var('PATH', '/opt/csw/bin')
     end
 
@@ -418,7 +418,7 @@ module Unix::Exec
   end
 
   def enable_remote_rsyslog(server = 'rsyslog.ops.puppetlabs.net', port = 514)
-    if !/ubuntu/.match?(self['platform'])
+    if !self['platform'].include?('ubuntu')
       @logger.warn "Enabling rsyslog is only implemented for ubuntu hosts"
       return
     end

--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -116,7 +116,7 @@ module Unix::File
     when /fedora|el|redhat|centos|cisco_nexus|cisco_ios_xr|opensuse|sles/
       variant = 'el' if ['centos', 'redhat'].include?(variant)
 
-      variant = 'redhatfips' if /redhatfips/.match?(self['packaging_platform'])
+      variant = 'redhatfips' if self['packaging_platform'].include?('redhatfips')
 
       if variant == 'cisco_nexus'
         variant = 'cisco-wrlinux'

--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -116,7 +116,7 @@ module Unix::File
     when /fedora|el|redhat|centos|cisco_nexus|cisco_ios_xr|opensuse|sles/
       variant = 'el' if ['centos', 'redhat'].include?(variant)
 
-      variant = 'redhatfips' if self['packaging_platform'].include?('redhatfips')
+      variant = 'redhatfips' if self['packaging_platform']&.include?('redhatfips')
 
       if variant == 'cisco_nexus'
         variant = 'cisco-wrlinux'

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -27,7 +27,7 @@ module Unix::Pkg
     case self['platform']
       when /sles-10/
         result = execute("zypper se -i --match-exact #{name}", opts) { |result| result }
-        /No packages found/.match?(result.stdout) ? (return false) : (return result.exit_code == 0)
+        result.stdout.include?('No packages found') ? (return false) : (return result.exit_code == 0)
       when /opensuse|sles-/
         if !self[:sles_rpmkeys_nightly_pl_imported]
           # The `:sles_rpmkeys_nightly_pl_imported` key is only read here at this
@@ -76,7 +76,7 @@ module Unix::Pkg
   # Except for the kernel. An upgrade will purge the modules for the currently running kernel
   # Before upgrading packages, we need to ensure we've the latest keyring
   def update_pacman_if_needed
-    if /archlinux/.match?(self['platform'])
+    if self['platform'].include?('archlinux')
       if @pacman_needs_update
         execute("pacman --sync --noconfirm --noprogressbar --refresh archlinux-keyring")
         execute("pacman --sync --noconfirm --noprogressbar --refresh --sysupgrade --ignore linux --ignore linux-docs --ignore linux-headers")
@@ -315,7 +315,7 @@ module Unix::Pkg
   #Examine the host system to determine the architecture
   #@return [Boolean] true if x86_64, false otherwise
   def determine_if_x86_64
-    if /solaris/.match?(self[:platform])
+    if self[:platform].include?('solaris')
       result = exec(Beaker::Command.new("uname -a | grep x86_64"), :accept_all_exit_codes => true)
         result.exit_code == 0
     else

--- a/lib/beaker/host/windows.rb
+++ b/lib/beaker/host/windows.rb
@@ -38,11 +38,11 @@ module Windows
       return @ssh_server if @ssh_server
       @ssh_server = :openssh
       status = execute('cmd.exe /c sc query BvSshServer', :accept_all_exit_codes => true)
-      if /4  RUNNING/.match?(status)
+      if status.include?('4  RUNNING')
         @ssh_server = :bitvise
       else
         status = execute('cmd.exe /c sc qc sshd', :accept_all_exit_codes => true)
-        if /C:\\Windows\\System32\\OpenSSH\\sshd\.exe/.match?(status)
+        if status.include?('C:\\Windows\\System32\\OpenSSH\\sshd.exe')
           @ssh_server = :win32_openssh
         end
       end

--- a/lib/beaker/host/windows.rb
+++ b/lib/beaker/host/windows.rb
@@ -38,11 +38,11 @@ module Windows
       return @ssh_server if @ssh_server
       @ssh_server = :openssh
       status = execute('cmd.exe /c sc query BvSshServer', :accept_all_exit_codes => true)
-      if status.include?('4  RUNNING')
+      if status&.include?('4  RUNNING')
         @ssh_server = :bitvise
       else
         status = execute('cmd.exe /c sc qc sshd', :accept_all_exit_codes => true)
-        if status.include?('C:\\Windows\\System32\\OpenSSH\\sshd.exe')
+        if status&.include?('C:\\Windows\\System32\\OpenSSH\\sshd.exe')
           @ssh_server = :win32_openssh
         end
       end

--- a/lib/beaker/host/windows/pkg.rb
+++ b/lib/beaker/host/windows/pkg.rb
@@ -89,7 +89,7 @@ module Windows::Pkg
 
   # @api private
   def identify_windows_architecture
-    /64/.match?(platform.arch) ? '64' : '32'
+    platform.arch.include?('64') ? '64' : '32'
   end
 
 end

--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -191,7 +191,7 @@ module Beaker
                   'slow (attempt to continue run post test failure)',
                   'stop (DEPRECATED, please use fast)',
                   '(default: slow)'  do |mode|
-            @cmd_options[:fail_mode] = /stop/.match?(mode) ? 'fast' :  mode
+            @cmd_options[:fail_mode] = mode.include?('stop') ? 'fast' :  mode
           end
 
           opts.on '--test-results-file /FILE/TO/SAVE/TO.rb',

--- a/lib/beaker/options/parser.rb
+++ b/lib/beaker/options/parser.rb
@@ -43,7 +43,7 @@ module Beaker
         arry = []
         if arg.is_a?(Array)
           arry += arg
-        elsif /,/.match?(arg)
+        elsif arg.include?(',')
           arry += arg.split(',')
         else
           arry << arg

--- a/lib/beaker/test_suite.rb
+++ b/lib/beaker/test_suite.rb
@@ -77,10 +77,10 @@ module Beaker
           @logger.warn msg
         when :fail
           @logger.error msg
-          break if !/slow/.match?(@fail_mode.to_s) #all failure modes except slow cause us to kick out early on failure
+          break if !@fail_mode.to_s.include?('slow') #all failure modes except slow cause us to kick out early on failure
         when :error
           @logger.warn msg
-          break if !/slow/.match?(@fail_mode.to_s) #all failure modes except slow cause us to kick out early on failure
+          break if !@fail_mode.to_s.include?('slow') #all failure modes except slow cause us to kick out early on failure
         end
       end
       @test_suite_results.stop_time = Time.now


### PR DESCRIPTION
rubocop-performance recently updated to 1.16.0 and its Performance/StringInclude cop identified several instances where Beaker was matching against regex when a less-expensive `String#include?` could be used.

This commit updates those regex instances.

See also: recent GitHub Actions Rubocop failures: https://github.com/voxpupuli/beaker/actions/runs/4119323790/jobs/7112852805#logs