### PR TITLE
Do not include Unix::Exec on Windows::Exec tests

### DIFF
--- a/spec/beaker/host/windows/exec_spec.rb
+++ b/spec/beaker/host/windows/exec_spec.rb
@@ -3,7 +3,6 @@ require 'spec_helper'
 module Beaker
   describe Windows::Exec do
     class WindowsExecTest
-      include Unix::Exec
       include Windows::Exec
 
       def initialize(hash, logger)
@@ -85,10 +84,10 @@ module Beaker
       let(:destination) { '/destination/path/of/content' }
 
       it 'rm first' do
-        expect( instance ).to receive(:execute).with("rm -rf #{destination}").and_return(0)
+        # only defined on unix/pswindows
+        expect(instance).to receive(:rm_rf).with(destination).and_return("rm -rf #{destination}")
         expect( instance ).to receive(:execute).with("mv \"#{origin}\" \"#{destination}\"").and_return(0)
         expect( instance.mv(origin, destination) ).to be === 0
-
       end
 
       it 'does not rm' do


### PR DESCRIPTION
I'm not 100% sure this is correct, but it feels wrong to have both in there.