### PR TITLE
rubocop: disable Gemspec/DevelopmentDependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ AllCops:
 Gemspec/RequireMFA:
   Enabled: false
 
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
 Style/TrailingCommaInHashLiteral:
   Enabled: True
   EnforcedStyleForMultiline: consistent_comma

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,13 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Configuration parameters: EnforcedStyle, AllowedGems, Include.
-# SupportedStyles: Gemfile, gems.rb, gemspec
-# Include: **/*.gemspec, **/Gemfile, **/gems.rb
-Gemspec/DevelopmentDependencies:
-  Exclude:
-    - 'beaker.gemspec'
-
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: enums
 Lint/ConstantDefinitionInBlock:


### PR DESCRIPTION
In all other gems we've this disabled in rubocop.yml as well.