### PR TITLE
Add a CI job we can enforce in branch protection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,3 +50,12 @@ jobs:
         run: bundle exec rake spec
       - name: Run acceptance tests
         run: bundle exec rake acceptance
+
+  tests:
+    needs:
+      - rubocop
+      - test
+    runs-on: ubuntu-latest
+    name: Test suite
+    steps:
+      - run: echo Test suite completed


### PR DESCRIPTION
This provides a generic name for a CI job. It will pass when all other jobs passed. As a result, we can configure it in the GitHub branch protection (like we do it in other repos already).