### PR TITLE
Introduce shareable rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,32 +1,7 @@
 ---
-inherit_from: .rubocop_todo.yml
-
-require:
-  - rubocop-performance
-  - rubocop-rake
-  - rubocop-rspec
-
-AllCops:
-  TargetRubyVersion: 2.7
-  NewCops: enable
-
-Gemspec/RequireMFA:
-  Enabled: false
-
-Gemspec/DevelopmentDependencies:
-  Enabled: false
-
-Style/TrailingCommaInHashLiteral:
-  Enabled: True
-  EnforcedStyleForMultiline: consistent_comma
-
-Style/TrailingCommaInArrayLiteral:
-  Enabled: True
-  EnforcedStyleForMultiline: consistent_comma
-
-Style/TrailingCommaInArguments:
-  Enabled: True
-  EnforcedStyleForMultiline: comma
+inherit_from:
+  - rubocop.yml
+  - .rubocop_todo.yml
 
 Layout/LineLength:
   Exclude:
@@ -67,9 +42,6 @@ RSpec/MultipleExpectations:
 
 RSpec/NestedGroups:
   Max: 4
-
-Metrics:
-  Enabled: false
 
 Style:
   Enabled: false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,0 +1,39 @@
+---
+# this file is the base rubocop config for beaker + all beaker plugins
+require:
+  - rubocop-performance
+  - rubocop-rake
+  - rubocop-rspec
+
+AllCops:
+  NewCops: enable
+  DisplayCopNames: true
+  ExtraDetails: true
+  DisplayStyleGuide: true
+  TargetRubyVersion: '2.7'
+  Exclude:
+  - vendor/**/*
+  - .vendor/**/*
+
+# this currently doesn't work with the way we handle our secrets
+Gemspec/RequireMFA:
+  Enabled: false
+
+# current Vox Pupuli default is to use `add_development_dependency` in the gemspec
+Gemspec/DevelopmentDependencies:
+  Enabled: false
+
+Style/TrailingCommaInHashLiteral:
+  Enabled: True
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: True
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInArguments:
+  Enabled: True
+  EnforcedStyleForMultiline: comma
+
+Metrics:
+  Enabled: false


### PR DESCRIPTION
This allows us to reuse the rubocop.yml in our beaker plugins