### PR TITLE
(maint) Backport 'Removes open_uri_redirections'

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -41,7 +41,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'net-ssh', '>= 5.0'
 
   s.add_runtime_dependency 'in-parallel', '~> 0.1'
-  s.add_runtime_dependency 'open_uri_redirections', '~> 0.2.1'
   s.add_runtime_dependency 'rsync', '~> 1.0.9'
   s.add_runtime_dependency 'thor', ['>= 1.0.1', '< 2.0']
 

--- a/lib/beaker/dsl/helpers/web_helpers.rb
+++ b/lib/beaker/dsl/helpers/web_helpers.rb
@@ -62,7 +62,7 @@ module Beaker
             logger.notify "Fetching: #{src}"
             logger.notify "  and saving to #{dst}"
             begin
-              URI.open(src) do |remote|
+              uri_open(src) do |remote|
                 File.open(dst, "w") do |file|
                   FileUtils.copy_stream(remote, file)
                 end
@@ -77,6 +77,19 @@ module Beaker
           end
           return dst
         end
+
+        def uri_open(src)
+          if RUBY_VERSION.to_f < 2.5
+            URI.send(:open, src) do |remote|
+              yield remote
+            end
+          else
+            URI.open(src) do |remote|
+              yield remote
+            end
+          end
+        end
+        private :uri_open
 
         # Recursively fetch the contents of the given http url, ignoring
         # `index.html` and `*.gif` files.

--- a/lib/beaker/dsl/helpers/web_helpers.rb
+++ b/lib/beaker/dsl/helpers/web_helpers.rb
@@ -52,7 +52,6 @@ module Beaker
         # @!visibility private
         def fetch_http_file(base_url, file_name, dst_dir)
           require 'open-uri'
-          require 'open_uri_redirections'
           FileUtils.makedirs(dst_dir)
           base_url.chomp!('/')
           src = "#{base_url}/#{file_name}"
@@ -63,7 +62,7 @@ module Beaker
             logger.notify "Fetching: #{src}"
             logger.notify "  and saving to #{dst}"
             begin
-              open(src, :allow_redirections => :all) do |remote|
+              URI.open(src) do |remote|
                 File.open(dst, "w") do |file|
                   FileUtils.copy_stream(remote, file)
                 end

--- a/spec/beaker/dsl/helpers/web_helpers_spec.rb
+++ b/spec/beaker/dsl/helpers/web_helpers_spec.rb
@@ -14,7 +14,7 @@ end
 
 describe ClassMixedWithDSLHelpers do
   let( :logger  ) { double("Beaker::Logger", :notify => nil , :debug => nil ) }
-  let( :url     ) { "http://beaker.tool" }
+  let( :url     ) { "http://example.com" }
   let( :name    ) { "name" }
   let( :destdir ) { "destdir" }
 
@@ -37,7 +37,7 @@ describe ClassMixedWithDSLHelpers do
         concat_path = "#{destdir}/#{name}"
         create_files([concat_path])
         allow(logger).to receive(:notify)
-        allow(subject).to receive(:open)
+        allow(URI).to receive(:open).with("#{url}/#{name}").and_return(status: 200)
         result = subject.fetch_http_file url, name, destdir
         expect(result).to eq(concat_path)
       end
@@ -45,7 +45,8 @@ describe ClassMixedWithDSLHelpers do
       it 'doesn\'t cache by default' do
         expect( logger ).to receive( :notify ).with( /^Fetching/ ).ordered
         expect( logger ).to receive( :notify ).with( /^\ \ and\ saving\ to\ / ).ordered
-        expect( subject ).to receive( :open )
+        allow(URI).to receive(:open).with("#{url}/#{name}").and_return(status: 200)
+        expect(URI).to receive(:open)
 
         subject.fetch_http_file( url, name, destdir )
       end
@@ -67,7 +68,8 @@ describe ClassMixedWithDSLHelpers do
 
           expect( logger ).to receive( :notify ).with( /^Fetching/ ).ordered
           expect( logger ).to receive( :notify ).with( /^\ \ and\ saving\ to\ / ).ordered
-          expect( subject ).to receive( :open )
+          allow(URI).to receive(:open).with("#{url}/#{name}").and_return(status: 200)
+          expect(URI).to receive(:open)
 
           subject.fetch_http_file( url, name, destdir )
         end
@@ -78,8 +80,9 @@ describe ClassMixedWithDSLHelpers do
     describe 'given invalid arguments' do
 
       it 'chomps correctly when given a URL ending with a / character' do
-        expect( subject ).to receive( :open ).with( "#{url}/#{name}", anything )
-        subject.fetch_http_file( url, name, destdir )
+        allow(URI).to receive(:open).with("#{url}/#{name}").and_return(status: 200)
+        expect( URI ).to receive( :open ).with( "#{url}/#{name}" )
+        subject.fetch_http_file( "#{url}/", name, destdir )
       end
 
     end


### PR DESCRIPTION
Prior to Ruby 2.4, the OpenURI module did not natively support HTTP => HTTPS redirections, necessitating a third-party gem, open_uri_redirections.

However, redirection functionality was added in Ruby 2.4:

https://github.com/ruby/ruby/commit/393ecc9f10016828a3713438ae216dc39b965364

And the `Kernel#open` method was deprecated in Ruby 2.7 and removed entirely in Ruby 3.0 in favor of the `URI#open` method:

https://bugs.ruby-lang.org/issues/15893

This commit removes the open_uri_redirections gem from the WebHelpers module and gemspec and replaces `Kernel#open` with `URI#open`.

(cherry picked from commit 46ba6bfaf4fe39b0ef4d73648fefe09a8aa36d22)