### PR TITLE
roles are not optional

### DIFF
--- a/docs/tutorials/creating_a_test_environment.md
+++ b/docs/tutorials/creating_a_test_environment.md
@@ -45,7 +45,7 @@ To properly define a host you must provide:
 
 * name: The string identifying this host.
 * platform: One of the Beaker supported platforms.
-* roles: The 'job' of this host, an array of `master`, `agent`, `frictionless`, `dashboard`, `database`, `default` or any user-defined string. At least one host needs a role of `default`.
+* roles: The 'job' of this host, an array of `master`, `agent`, `frictionless`, `dashboard`, `database`, `default` or any user-defined string. One host needs the role of `default`.
 
 ## Optional Host Settings
 

--- a/docs/tutorials/creating_a_test_environment.md
+++ b/docs/tutorials/creating_a_test_environment.md
@@ -45,7 +45,7 @@ To properly define a host you must provide:
 
 * name: The string identifying this host.
 * platform: One of the Beaker supported platforms.
-* roles: The 'job' of this host, an array of `master`, `agent`, `frictionless`, `dashboard`, `database`, `default` or any user-defined string. One host needs the role of `default`.
+* roles: In a multi-host setup roles are mandatory. One host needs the role of `default`. Roles describe the 'job' of a host, an array of `master`, `agent`, `frictionless`, `dashboard`, `database`, `default` or any user-defined string.
 
 ## Optional Host Settings
 
@@ -55,6 +55,7 @@ Additionally, Beaker supports the following host options:
 * hypervisor: One of `docker`, `solaris`, `ec2`, `vsphere`, `fusion`, `aix`, `vcloud` or `vagrant`.
   * Additional settings may be required depending on the selected hypervisor (ie, template, box, box_url, etc).  Check the documentation below for your hypervisor for details.
 * snapshot: The name of the snapshot to revert to before testing.
+* roles: In a single-host setup roles are optional. Roles describe the 'job' of a host, an array of `master`, `agent`, `frictionless`, `dashboard`, `database`, `default` or any user-defined string.
 * pe_dir: The directory where PE builds are located, may be local directory or a URL.
 * pe_ver: The version number of PE to install.
 * vagrant_memsize: The memory size (in MB) for this host

--- a/docs/tutorials/creating_a_test_environment.md
+++ b/docs/tutorials/creating_a_test_environment.md
@@ -45,6 +45,7 @@ To properly define a host you must provide:
 
 * name: The string identifying this host.
 * platform: One of the Beaker supported platforms.
+* roles: The 'job' of this host, an array of `master`, `agent`, `frictionless`, `dashboard`, `database`, `default` or any user-defined string. At least one host needs a role of `default`.
 
 ## Optional Host Settings
 
@@ -54,7 +55,6 @@ Additionally, Beaker supports the following host options:
 * hypervisor: One of `docker`, `solaris`, `ec2`, `vsphere`, `fusion`, `aix`, `vcloud` or `vagrant`.
   * Additional settings may be required depending on the selected hypervisor (ie, template, box, box_url, etc).  Check the documentation below for your hypervisor for details.
 * snapshot: The name of the snapshot to revert to before testing.
-* roles: The 'job' of this host, an array of `master`, `agent`, `frictionless`, `dashboard`, `database`, `default` or any user-defined string.
 * pe_dir: The directory where PE builds are located, may be local directory or a URL.
 * pe_ver: The version number of PE to install.
 * vagrant_memsize: The memory size (in MB) for this host


### PR DESCRIPTION
if one does not set any role, you get an error

```bash
     Failure/Error: it { is_expected.to be_installed }
     Beaker::DSL::Outcomes::FailTest:
       There should be one host with default defined!
```

One and only one is allowed to be default.
```
Failure/Error: configure_beaker
ArgumentError:
  Only one host may have the role 'default', default roles assigned to [:"ubuntu-20-04", :"ubuntu-18-04", :"ubuntu-22-04"]
```