### PR TITLE
Declare API interface on Beaker::Host

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -547,6 +547,30 @@ module Beaker
 
       raise Beaker::Host::CommandFailure, result.error
     end
+
+    def tmpfile(name = '')
+      raise NotImplementedError
+    end
+
+    def tmpdir(name = '')
+      raise NotImplementedError
+    end
+
+    def path_split(paths)
+      raise NotImplementedError
+    end
+
+    def rm_rf(path)
+      raise NotImplementedError
+    end
+
+    def install_package(package, cmdline_args = nil, _version = nil, opts = {})
+      raise NotImplementedError
+    end
+
+    def add_env_var(key, val)
+      raise NotImplementedError
+    end
   end
 
   %w[

--- a/lib/beaker/host/freebsd/pkg.rb
+++ b/lib/beaker/host/freebsd/pkg.rb
@@ -16,7 +16,7 @@ module FreeBSD::Pkg
     execute("/bin/sh -c '#{check_pkgng_sh}'", opts) { |r| r }.exit_code == 0
   end
 
-  def install_package(package, cmdline_args = nil, opts = {})
+  def install_package(package, cmdline_args = nil, _version = nil, opts = {})
     cmd = if pkgng_active?
             "pkg install #{cmdline_args || '-y'} #{package}"
           else


### PR DESCRIPTION
All subclasses of Beaker::Host implement this, so this declares the API.  This is useful for consumers who want to use instance_double(Beaker::Host) and then call tmpfile.