### PR TITLE
Disable RSpec/IndexedLet

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,9 @@ RSpec/StubbedMock:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/IndexedLet:
+  Enabled: false
+
 RSpec/NestedGroups:
   Max: 4
 


### PR DESCRIPTION
Caused by https://github.com/voxpupuli/voxpupuli-rubocop/commit/bde6dd440601d179e65956be11a2a51208c42320