### PR TITLE
Add bcrypt_pbkdf to fix ed25519 ssh keys support

### DIFF
--- a/beaker.gemspec
+++ b/beaker.gemspec
@@ -29,7 +29,10 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'minitest', '~> 5.4'
   s.add_runtime_dependency 'rexml'
 
-  s.add_runtime_dependency 'ed25519', '~> 1.0' # net-ssh compatibility with ed25519 keys
+  # net-ssh compatibility with ed25519 keys
+  s.add_runtime_dependency 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
+  s.add_runtime_dependency 'ed25519', '>= 1.2', '<2.0'
+
   s.add_runtime_dependency 'hocon', '~> 1.0'
   s.add_runtime_dependency 'inifile', '~> 3.0'
   s.add_runtime_dependency 'net-scp', '>= 1.2', '< 5.0'


### PR DESCRIPTION
This is to fix the following Beaker error:
```
NotImplementedError: unsupported key type `ssh-ed25519'
net-ssh requires the following gems for ed25519 support:
 * ed25519 (>= 1.2, < 2.0)
 * bcrypt_pbkdf (>= 1.0, < 2.0)
See https://github.com/net-ssh/net-ssh/issues/565 for more information
Gem::LoadError : "bcrypt_pbkdf is not part of the bundle. Add it to your Gemfile."
```