### PR TITLE
(maint) Update Minitest capitalization

### DIFF
--- a/acceptance/lib/helpers/test_helper.rb
+++ b/acceptance/lib/helpers/test_helper.rb
@@ -59,7 +59,7 @@ end
 #      assert_equal expected, user
 #    end
 #
-# Absorbs any MiniTest::Assertion from a failing test assertion in the block.
+# Absorbs any Minitest::Assertion from a failing test assertion in the block.
 # This implies that the intermittent failure is caught and the suite will not
 # go red for this failure. Intended to be used with the Jenkins Build Failure
 # Analyzer (or similar), to detect these failures without failing the build.
@@ -70,7 +70,7 @@ def fails_intermittently(issue_link, args = {})
   raise ArgumentError, "a block is required" unless block_given?
 
   yield
-rescue MiniTest::Assertion, StandardError, SignalException # we have a test failure!
+rescue Minitest::Assertion, StandardError, SignalException # we have a test failure!
   STDERR.puts "\n\nIntermittent test failure! See: #{issue_link}"
 
   if args.empty?

--- a/lib/beaker.rb
+++ b/lib/beaker.rb
@@ -35,6 +35,6 @@ module Beaker
   # Shared methods and helpers
   require 'beaker/shared'
 
-  # MiniTest, for including MiniTest::Assertions
+  # Minitest, for including Minitest::Assertions
   require 'minitest/test'
 end

--- a/lib/beaker/options/command_line_parser.rb
+++ b/lib/beaker/options/command_line_parser.rb
@@ -248,7 +248,7 @@ module Beaker
 
           opts.on '--[no-]debug',
                   'DEPRECATED, use --log-level' do |bool|
-            @cmd_options[:log_level] =  bool ? 'debug' : 'info'
+            @cmd_options[:log_level] = bool ? 'debug' : 'info'
           end
 
           opts.on '-x', '--[no-]xml',

--- a/lib/beaker/test_case.rb
+++ b/lib/beaker/test_case.rb
@@ -22,7 +22,7 @@ module Beaker
     include Beaker::DSL
 
     # The Exception raised by Ruby's STDLIB's test framework (Ruby 1.9)
-    TEST_EXCEPTION_CLASS = ::MiniTest::Assertion
+    TEST_EXCEPTION_CLASS = ::Minitest::Assertion
 
     # Necessary for implementing {Beaker::DSL::Helpers#confine}.
     # Assumed to be an array of valid {Beaker::Host} objects for

--- a/spec/beaker/dsl/assertions_spec.rb
+++ b/spec/beaker/dsl/assertions_spec.rb
@@ -79,7 +79,7 @@ EXPECT
         expect(result).to receive(:output).and_return(output)
 
         expect(subject).to receive(:result).at_least(:once).and_return(result)
-        expect { subject.assert_output expectation }.to raise_error(MiniTest::Assertion)
+        expect { subject.assert_output expectation }.to raise_error(Minitest::Assertion)
       end
     end
   end

--- a/spec/beaker/dsl/structure_spec.rb
+++ b/spec/beaker/dsl/structure_spec.rb
@@ -196,11 +196,11 @@ describe ClassMixedWithDSLStructure do
   end
 
   describe '#expect_failure' do
-    it 'passes when a MiniTest assertion is raised' do
+    it 'passes when a Minitest assertion is raised' do
       expect(subject).to receive(:logger).and_return(logger)
       expect(logger).to receive(:notify)
       # We changed this lambda to use the simplest assert possible; using assert_equal
-      # caused an error in minitest 5.9.0 trying to write to the file system.
+      # caused an error in Minitest 5.9.0 trying to write to the file system.
       block = -> { assert(false, 'this assertion should be caught') }
       expect { subject.expect_failure 'this is an expected failure', &block }.not_to raise_error
     end
@@ -212,9 +212,9 @@ describe ClassMixedWithDSLStructure do
       expect { subject.expect_failure 'this is an expected failure', &block }.not_to raise_error
     end
 
-    it 'fails when a non-Beaker, non-MiniTest assertion is raised' do
-      block = -> { raise 'not a Beaker or MiniTest error' }
-      expect { subject.expect_failure 'this has a non-Beaker, non-MiniTest exception', &block }.to raise_error(RuntimeError, /not a Beaker or MiniTest error/)
+    it 'fails when a non-Beaker, non-Minitest assertion is raised' do
+      block = -> { raise 'not a Beaker or Minitest error' }
+      expect { subject.expect_failure 'this has a non-Beaker, non-Minitest exception', &block }.to raise_error(RuntimeError, /not a Beaker or Minitest error/)
     end
 
     it 'fails when no assertion is raised' do

--- a/spec/beaker/host/mac/group_spec.rb
+++ b/spec/beaker/host/mac/group_spec.rb
@@ -52,7 +52,7 @@ describe MacGroupTest do
       result.stdout = ''
       group_name = 'any_name'
       expect(subject).to receive(:execute).and_yield(result)
-      expect { subject.group_get(group_name) }.to raise_error(MiniTest::Assertion, "failed to get group #{group_name}")
+      expect { subject.group_get(group_name) }.to raise_error(Minitest::Assertion, "failed to get group #{group_name}")
     end
 
     it 'parses mac dscacheutil output into /etc/group format correctly' do

--- a/spec/beaker/host/mac/user_spec.rb
+++ b/spec/beaker/host/mac/user_spec.rb
@@ -63,7 +63,7 @@ describe MacUserTest do
       result.stdout = ''
       user_name = 'any_name'
       expect(subject).to receive(:execute).and_yield(result)
-      expect { subject.user_get(user_name) }.to raise_error(MiniTest::Assertion, "failed to get user #{user_name}")
+      expect { subject.user_get(user_name) }.to raise_error(Minitest::Assertion, "failed to get user #{user_name}")
     end
 
     it 'yields correctly with the result object' do


### PR DESCRIPTION
Minitest v5.19.0, released today, includes a commit[1] that only calls its compatibility layer when using an environment variable ("MT_COMPAT").

This means that calling "MiniTest" (with a capital "T") instead of "Minitest" (with all lowercase "T"s) no longer works.

This commit replaces all instances of "MiniTest" with "Minitest."

[1] https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6