### PR TITLE
(maint) Use DNF as Amazon Linux 2023 package manager

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -96,7 +96,7 @@ module Unix::Pkg
           name = "#{name}-#{version}"
         end
         execute("dnf -y #{cmdline_args} install #{name}", opts)
-      when /amazon|cisco|fedora|centos|redhat|eos|el-/
+      when /amazon-2023|cisco|fedora|centos|redhat|eos|el-/
         if version
           name = "#{name}-#{version}"
         end
@@ -183,7 +183,7 @@ module Unix::Pkg
       execute("zypper --non-interactive rm #{name}", opts)
     when /el-4/
       @logger.debug("Package uninstallation not supported on rhel4")
-    when /amazon|fedora-(2[2-9]|3[0-9])/
+    when /amazon-2023|fedora-(2[2-9]|3[0-9])/
       execute("dnf -y #{cmdline_args} remove #{name}", opts)
     when /cisco|fedora|centos|redhat|eos|el-/
       execute("yum -y #{cmdline_args} remove #{name}", opts)

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -91,12 +91,12 @@ module Unix::Pkg
         execute("zypper --non-interactive --gpg-auto-import-keys in #{name}", opts)
       when /el-4/
         @logger.debug("Package installation not supported on rhel4")
-      when /fedora-(2[2-9]|3[0-9])/
+      when /amazon-2023|fedora-(2[2-9]|3[0-9])/
         if version
           name = "#{name}-#{version}"
         end
         execute("dnf -y #{cmdline_args} install #{name}", opts)
-      when /amazon-2023|cisco|fedora|centos|redhat|eos|el-/
+      when /cisco|fedora|centos|redhat|eos|el-/
         if version
           name = "#{name}-#{version}"
         end

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -270,7 +270,7 @@ module Beaker
       it "uses dnf on amazon-2023" do
         @opts = { 'platform' => "amazon-2023-is-me" }
         pkg = 'amazon_package'
-        expect(Beaker::Command).to receive(:new).with("yum -y  install #{pkg}", [], { :prepend_cmds => nil, :cmdexe => false }).and_return('')
+        expect(Beaker::Command).to receive(:new).with("dnf -y  install #{pkg}", [], { :prepend_cmds => nil, :cmdexe => false }).and_return('')
         expect(instance).to receive(:exec).with('', {}).and_return(generate_result("hello", { :exit_code => 0 }))
         expect(instance.install_package(pkg)).to be == "hello"
       end


### PR DESCRIPTION
AWS's documentation states: "In Amazon Linux 2 and Amazon Linux, the default software package management tool is YUM. In Amazon Linux 2023, the default software package management tool is DNF."[1]

This commit updates the install_package and uninstall_package methods to leverage DNF instead of Yum for Amazon Linux 2023 specifically (not Amazon Linux or Amazon Linux 2).

[1] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/find-install-software.html