### PR TITLE
Use DNF for Amazon Linux 2023

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -172,7 +172,7 @@ module Unix::Pkg
       execute("zypper --non-interactive rm #{name}", opts)
     when /el-4/
       @logger.debug("Package uninstallation not supported on rhel4")
-    when /amazon|edora-(2[2-9]|3[0-9])/
+    when /amazon|fedora-(2[2-9]|3[0-9])/
       execute("dnf -y #{cmdline_args} remove #{name}", opts)
     when /cisco|fedora|centos|redhat|eos|el-/
       execute("yum -y #{cmdline_args} remove #{name}", opts)

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -87,7 +87,7 @@ module Unix::Pkg
       execute("zypper --non-interactive --gpg-auto-import-keys in #{name}", opts)
     when /el-4/
       @logger.debug("Package installation not supported on rhel4")
-    when /amazon|fedora-(2[2-9]|3[0-9])/
+    when /amazon-2023|fedora-(2[2-9]|3[0-9])/
       name = "#{name}-#{version}" if version
       execute("dnf -y #{cmdline_args} install #{name}", opts)
     when /cisco|fedora|centos|redhat|eos|el-/
@@ -172,7 +172,7 @@ module Unix::Pkg
       execute("zypper --non-interactive rm #{name}", opts)
     when /el-4/
       @logger.debug("Package uninstallation not supported on rhel4")
-    when /amazon|fedora-(2[2-9]|3[0-9])/
+    when /amazon-2023|fedora-(2[2-9]|3[0-9])/
       execute("dnf -y #{cmdline_args} remove #{name}", opts)
     when /cisco|fedora|centos|redhat|eos|el-/
       execute("yum -y #{cmdline_args} remove #{name}", opts)


### PR DESCRIPTION
Prior to this, Beaker used DNF for every type of Amazon Linux. However, DNF is only the default package manager for Amazon Linux >= 2023