### PR TITLE
Use DNF for Fedora, newer Enterprise Linux

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -87,10 +87,10 @@ module Unix::Pkg
       execute("zypper --non-interactive --gpg-auto-import-keys in #{name}", opts)
     when /el-4/
       @logger.debug("Package installation not supported on rhel4")
-    when /amazon-2023|el-(8|9|1[0-9])|fedora-(2[2-9]|3[0-9])/
+    when /amazon-2023|el-(8|9|1[0-9])|fedora/
       name = "#{name}-#{version}" if version
       execute("dnf -y #{cmdline_args} install #{name}", opts)
-    when /cisco|fedora|centos|redhat|eos|el-[1-7]-/
+    when /cisco|centos|redhat|eos|el-[1-7]-/
       name = "#{name}-#{version}" if version
       execute("yum -y #{cmdline_args} install #{name}", opts)
     when /ubuntu|debian|cumulus|huaweios/
@@ -172,9 +172,9 @@ module Unix::Pkg
       execute("zypper --non-interactive rm #{name}", opts)
     when /el-4/
       @logger.debug("Package uninstallation not supported on rhel4")
-    when /amazon-2023|el-(8|9|1[0-9])|fedora-(2[2-9]|3[0-9])/
+    when /amazon-2023|el-(8|9|1[0-9])|fedora/
       execute("dnf -y #{cmdline_args} remove #{name}", opts)
-    when /cisco|fedora|centos|redhat|eos|el-[1-7]-/
+    when /cisco|centos|redhat|eos|el-[1-7]-/
       execute("yum -y #{cmdline_args} remove #{name}", opts)
     when /ubuntu|debian|cumulus|huaweios/
       execute("apt-get purge #{cmdline_args} -y #{name}", opts)

--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -87,10 +87,10 @@ module Unix::Pkg
       execute("zypper --non-interactive --gpg-auto-import-keys in #{name}", opts)
     when /el-4/
       @logger.debug("Package installation not supported on rhel4")
-    when /amazon-2023|fedora-(2[2-9]|3[0-9])/
+    when /amazon-2023|el-(8|9|1[0-9])|fedora-(2[2-9]|3[0-9])/
       name = "#{name}-#{version}" if version
       execute("dnf -y #{cmdline_args} install #{name}", opts)
-    when /cisco|fedora|centos|redhat|eos|el-/
+    when /cisco|fedora|centos|redhat|eos|el-[1-7]-/
       name = "#{name}-#{version}" if version
       execute("yum -y #{cmdline_args} install #{name}", opts)
     when /ubuntu|debian|cumulus|huaweios/
@@ -172,9 +172,9 @@ module Unix::Pkg
       execute("zypper --non-interactive rm #{name}", opts)
     when /el-4/
       @logger.debug("Package uninstallation not supported on rhel4")
-    when /amazon-2023|fedora-(2[2-9]|3[0-9])/
+    when /amazon-2023|el-(8|9|1[0-9])|fedora-(2[2-9]|3[0-9])/
       execute("dnf -y #{cmdline_args} remove #{name}", opts)
-    when /cisco|fedora|centos|redhat|eos|el-/
+    when /cisco|fedora|centos|redhat|eos|el-[1-7]-/
       execute("yum -y #{cmdline_args} remove #{name}", opts)
     when /ubuntu|debian|cumulus|huaweios/
       execute("apt-get purge #{cmdline_args} -y #{name}", opts)

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -175,24 +175,12 @@ module Beaker
         end
       end
 
-      (1..21).to_a.each do |fedora_release|
-        it "uses yum on fedora-#{fedora_release}" do
-          @opts = { 'platform' => "fedora-#{fedora_release}-is-me" }
-          pkg = 'fedora_package'
-          expect(Beaker::Command).to receive(:new).with("yum -y  install #{pkg}", [], { :prepend_cmds => nil, :cmdexe => false }).and_return('')
-          expect(instance).to receive(:exec).with('', {}).and_return(generate_result("hello", { :exit_code => 0 }))
-          expect(instance.install_package(pkg)).to be == "hello"
-        end
-      end
-
-      (22..39).to_a.each do |fedora_release|
-        it "uses dnf on fedora-#{fedora_release}" do
-          @opts = { 'platform' => "fedora-#{fedora_release}-is-me" }
-          pkg = 'fedora_package'
-          expect(Beaker::Command).to receive(:new).with("dnf -y  install #{pkg}", [], { :prepend_cmds => nil, :cmdexe => false }).and_return('')
-          expect(instance).to receive(:exec).with('', {}).and_return(generate_result("hello", { :exit_code => 0 }))
-          expect(instance.install_package(pkg)).to be == "hello"
-        end
+      it "uses dnf on fedora" do
+        @opts = { 'platform' => "fedora-is-me" }
+        pkg = 'fedora_package'
+        expect(Beaker::Command).to receive(:new).with("dnf -y  install #{pkg}", [], { :prepend_cmds => nil, :cmdexe => false }).and_return('')
+        expect(instance).to receive(:exec).with('', {}).and_return(generate_result("hello", { :exit_code => 0 }))
+        expect(instance.install_package(pkg)).to be == "hello"
       end
 
       it "uses dnf on amazon-2023" do
@@ -221,24 +209,12 @@ module Beaker
           expect(instance.uninstall_package('pkg')).to be == "hello"
         end
 
-        (1..21).to_a.each do |fedora_release|
-          it "uses yum on fedora-#{fedora_release}" do
-            @opts = { 'platform' => "fedora-#{fedora_release}-is-me" }
-            pkg = 'fedora_package'
-            expect(Beaker::Command).to receive(:new).with("yum -y  remove #{pkg}", [], { :prepend_cmds => nil, :cmdexe => false }).and_return('')
-            expect(instance).to receive(:exec).with('', {}).and_return(generate_result("hello", { :exit_code => 0 }))
-            expect(instance.uninstall_package(pkg)).to be == "hello"
-          end
-        end
-
-        (22..39).to_a.each do |fedora_release|
-          it "uses dnf on fedora-#{fedora_release}" do
-            @opts = { 'platform' => "fedora-#{fedora_release}-is-me" }
-            pkg = 'fedora_package'
-            expect(Beaker::Command).to receive(:new).with("dnf -y  remove #{pkg}", [], { :prepend_cmds => nil, :cmdexe => false }).and_return('')
-            expect(instance).to receive(:exec).with('', {}).and_return(generate_result("hello", { :exit_code => 0 }))
-            expect(instance.uninstall_package(pkg)).to be == "hello"
-          end
+        it "uses dnf on fedora" do
+          @opts = { 'platform' => "fedora-is-me" }
+          pkg = 'fedora_package'
+          expect(Beaker::Command).to receive(:new).with("dnf -y  remove #{pkg}", [], { :prepend_cmds => nil, :cmdexe => false }).and_return('')
+          expect(instance).to receive(:exec).with('', {}).and_return(generate_result("hello", { :exit_code => 0 }))
+          expect(instance.uninstall_package(pkg)).to be == "hello"
         end
       end
     end


### PR DESCRIPTION
Prior to this commit, the install_package and uninstall_package methods used Yum for all versions of Red Hat Enterprise Linux. However, RHEL has used DNF as its default package manager since version 8.

This commit updates those methods to use DNF for RHEL 8, 9, and any future versions and to explicitly use Yum on RHEL versions 1-7.