### PR TITLE
(maint) permit PlatformTagContainer class

### DIFF
--- a/lib/beaker/options/hosts_file_parser.rb
+++ b/lib/beaker/options/hosts_file_parser.rb
@@ -4,6 +4,7 @@ module Beaker
     module HostsFileParser
       PERMITTED_YAML_CLASSES = [
         'Beaker',
+        'Beaker::DSL::TestTagging::PlatformTagConfiner',
         'Beaker::Logger',
         'Beaker::Options::OptionsHash',
         'Beaker::Platform',


### PR DESCRIPTION
This commit adds the PlatformTagContainer class to the HostsFileParser module so that tests can be re-run. This class was added to the 5.x series in a previous commit [1] but was not added to the 4.x branch. For context see issue #1753 

[1]: 45f0bf93577b744bda6843b372e0f3c8319fc5f5
[2]: https://github.com/voxpupuli/beaker/issues/1753