### PR TITLE
Ensure platform is Beaker::Platform in tests

### DIFF
--- a/spec/beaker/command_spec.rb
+++ b/spec/beaker/command_spec.rb
@@ -125,7 +125,7 @@ module Beaker
       allow(h).to receive(:append_commands).and_return('')
       h
     end
-    let(:platform)    { @platform   || 'unix' }
+    let(:platform)    { @platform   || 'el-9-64' }
     let(:expression)  { @expression || 's/b/s/' }
     let(:filename)    { @filename   || '/fakefile' }
     let(:options)     { @options    || {} }

--- a/spec/beaker/host/windows/file_spec.rb
+++ b/spec/beaker/host/windows/file_spec.rb
@@ -6,7 +6,7 @@ module Beaker
     let(:group) { 'somegroup' }
     let(:path) { 'C:\Foo\Bar' }
     let(:newpath) { '/Foo/Bar' }
-    let(:host)    { make_host('name', { :platform => 'windows' }) }
+    let(:host)    { make_host('name', { :platform => 'windows-11-64' }) }
 
     describe '#chown' do
       it 'calls cygpath first' do
@@ -60,7 +60,7 @@ module Beaker
       end
 
       it 'replaces backslashes with forward slashes when using BitVise and powershell' do
-        host = make_host('name', platform: 'windows', is_cygwin: false)
+        host = make_host('name', platform: 'windows-11-64', is_cygwin: false)
         allow(host).to receive(:determine_ssh_server).and_return(:bitvise)
         expect(host.scp_path(path)).to eq('C:/Windows')
       end

--- a/spec/beaker/host_spec.rb
+++ b/spec/beaker/host_spec.rb
@@ -7,7 +7,7 @@ module Beaker
     let(:host)    { make_host('name', options.merge(platform)) }
 
     it 'creates a windows host given a windows config' do
-      @platform = 'windows'
+      @platform = 'windows-11-64'
       expect(host).to be_a Windows::Host
     end
 
@@ -109,16 +109,16 @@ module Beaker
         result.exit_code = 0
         expect(Beaker::Command).to receive(:new).with(/grep \^key= ~\/\.ssh\/environment/)
         expect(host).to receive(:exec).and_return(result)
-        expect(Beaker::SedCommand).to receive(:new).with('unix', 's/^key=/key=\\/my\\/first\\/value:/', '~/.ssh/environment')
+        expect(Beaker::SedCommand).to receive(:new).with('el-9-64', 's/^key=/key=\\/my\\/first\\/value:/', '~/.ssh/environment')
         host.add_env_var('key', '/my/first/value')
       end
     end
 
     describe "#delete_env_var" do
       it "deletes env var" do
-        expect(Beaker::SedCommand).to receive(:new).with('unix', '/key=\\/my\\/first\\/value$/d', '~/.ssh/environment')
-        expect(Beaker::SedCommand).to receive(:new).with("unix", "s/key=\\(.*\\)[;:]\\/my\\/first\\/value/key=\\1/", "~/.ssh/environment")
-        expect(Beaker::SedCommand).to receive(:new).with("unix", "s/key=\\/my\\/first\\/value[;:]/key=/", "~/.ssh/environment")
+        expect(Beaker::SedCommand).to receive(:new).with('el-9-64', '/key=\\/my\\/first\\/value$/d', '~/.ssh/environment')
+        expect(Beaker::SedCommand).to receive(:new).with("el-9-64", "s/key=\\(.*\\)[;:]\\/my\\/first\\/value/key=\\1/", "~/.ssh/environment")
+        expect(Beaker::SedCommand).to receive(:new).with("el-9-64", "s/key=\\/my\\/first\\/value[;:]/key=/", "~/.ssh/environment")
         host.delete_env_var('key', '/my/first/value')
       end
     end
@@ -250,7 +250,7 @@ module Beaker
     describe "#mkdir_p" do
       it "does the right thing on a bash host, identified as is_cygwin=true" do
         @options = { :is_cygwin => true }
-        @platform = 'windows'
+        @platform = 'windows-11-64'
         result = double
         allow(result).to receive(:exit_code).and_return(0)
         allow(host).to receive(:exec).and_return(result)
@@ -261,7 +261,7 @@ module Beaker
 
       it "does the right thing on a bash host, identified as is_cygwin=nil" do
         @options = { :is_cygwin => nil }
-        @platform = 'windows'
+        @platform = 'windows-11-64'
         result = double
         allow(result).to receive(:exit_code).and_return(0)
         allow(host).to receive(:exec).and_return(result)
@@ -272,7 +272,7 @@ module Beaker
 
       it "does the right thing on a non-bash host, identified as is_cygwin=false (powershell)" do
         @options = { :is_cygwin => false }
-        @platform = 'windows'
+        @platform = 'windows-11-64'
         result = double
         allow(result).to receive(:exit_code).and_return(0)
         allow(host).to receive(:exec).and_return(result)
@@ -290,19 +290,17 @@ module Beaker
 
     describe "#touch" do
       it "generates the right absolute command for a windows host" do
-        @platform = 'windows'
+        @platform = 'windows-11-64'
         expect(host.touch('touched_file')).to eq "c:\\\\windows\\\\system32\\\\cmd.exe /c echo. 2> touched_file"
       end
 
-      %w[centos redhat].each do |platform|
-        it "generates the right absolute command for a #{platform} host" do
-          @platform = platform
-          expect(host.touch('touched_file')).to eq "/bin/touch touched_file"
-        end
+      it "generates the right absolute command for an el-9-64 host" do
+        @platform = 'el-9-64'
+        expect(host.touch('touched_file')).to eq "/bin/touch touched_file"
       end
 
-      it "generates the right absolute command for an osx host" do
-        @platform = 'osx'
+      it "generates the right absolute command for an osx-12-64 host" do
+        @platform = 'osx-12-64'
         expect(host.touch('touched_file')).to eq "/usr/bin/touch touched_file"
       end
     end
@@ -762,12 +760,12 @@ module Beaker
 
     describe "#fips_mode?" do
       it 'returns false on non-linux hosts' do
-        @platform = 'windows'
+        @platform = 'windows-11-64'
         expect(host).to receive(:file_exist?).with('/proc/sys/crypto/fips_enabled').and_return(false)
         expect(host.fips_mode?).to be false
       end
 
-      platforms = %w[el-7 el-8 centos]
+      platforms = %w[el-7-64 el-8-64 centos-9-64]
 
       platforms.each do |platform|
         context "on #{platform}" do

--- a/spec/beaker/hypervisor/hypervisor_spec.rb
+++ b/spec/beaker/hypervisor/hypervisor_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module Beaker
   describe Hypervisor do
-    let(:hosts) { make_hosts({ :platform => 'el-5' }) }
+    let(:hosts) { make_hosts({ :platform => 'el-9-64' }) }
 
     describe "#create" do
       let(:hypervisor) { described_class }

--- a/spec/beaker/perf_spec.rb
+++ b/spec/beaker/perf_spec.rb
@@ -30,7 +30,7 @@ module Beaker
         @my_logger.remove_destination(STDOUT)
         perf = described_class.new(hosts, @options)
         expect(perf).to be_a described_class
-        expect(@my_io.string).to match(/Setup perf on host: myHost/)
+        expect(@my_io.string).to eq("Setup perf on host: myHost\n")
       end
 
       it 'creates a new Perf object with multiple hosts' do
@@ -39,7 +39,7 @@ module Beaker
         @my_logger.remove_destination(STDOUT)
         perf = described_class.new(hosts, @options)
         expect(perf).to be_a described_class
-        expect(@my_io.string).to match(/Setup perf on host: myHost*\nSetup perf on host: myOtherHost/)
+        expect(@my_io.string).to eq("Setup perf on host: myHost\nSetup perf on host: myOtherHost\n")
       end
 
       it 'creates a new Perf object with multiple hosts, SLES' do
@@ -50,7 +50,7 @@ module Beaker
         @my_logger.remove_destination(STDOUT)
         perf = described_class.new(hosts, @options)
         expect(perf).to be_a described_class
-        expect(@my_io.string).to match(/Setup perf on host: myHost\nSetup perf on host: myOtherHost/)
+        expect(@my_io.string).to include("Setup perf on host: myHost\nSetup perf on host: myOtherHost\n")
       end
     end
 
@@ -73,7 +73,7 @@ module Beaker
         perf = described_class.new(@hosts, @options)
         expect(perf).to be_a described_class
         perf.print_perf_info
-        expect(@my_io.string).to match(/Setup perf on host: myHost\nSetup perf on host: myOtherHost\nPerf \(sysstat\) not supported on host: myOtherHost\nGetting perf data for host: myHost\nGetting perf data for host: myOtherHost\nPerf \(sysstat\) not supported on host: myOtherHost/)
+        expect(@my_io.string).to eq("Setup perf on host: myHost\nSetup perf on host: myOtherHost\nPerf (sysstat) not supported on host: myOtherHost\nGetting perf data for host: myHost\nGetting perf data for host: myOtherHost\nPerf (sysstat) not supported on host: myOtherHost\n")
       end
 
       it "Does the Right Thing on non-Linux hosts" do
@@ -82,7 +82,7 @@ module Beaker
         perf = described_class.new(@hosts, @options)
         expect(perf).to be_a described_class
         perf.print_perf_info
-        expect(@my_io.string).to match(/Setup perf on host: myHost\nPerf \(sysstat\) not supported on host: myHost\nSetup perf on host: myOtherHost\nPerf \(sysstat\) not supported on host: myOtherHost\nGetting perf data for host: myHost\nPerf \(sysstat\) not supported on host: myHost\nGetting perf data for host: myOtherHost\nPerf \(sysstat\) not supported on host: myOtherHost/)
+        expect(@my_io.string).to eq("Setup perf on host: myHost\nPerf (sysstat) not supported on host: myHost\nSetup perf on host: myOtherHost\nPerf (sysstat) not supported on host: myOtherHost\nGetting perf data for host: myHost\nPerf (sysstat) not supported on host: myHost\nGetting perf data for host: myOtherHost\nPerf (sysstat) not supported on host: myOtherHost\n")
       end
     end
   end

--- a/spec/beaker/perf_spec.rb
+++ b/spec/beaker/perf_spec.rb
@@ -25,8 +25,7 @@ module Beaker
       end
 
       it 'creates a new Perf object with a single host' do
-        hosts = [make_host("myHost", @options)]
-        hosts.each { |host| host['platform'] = "centos-6-x86_64" }
+        hosts = [make_host("myHost", @options.merge('platform' => 'centos-6-64'))]
         @my_logger.remove_destination(STDOUT)
         perf = described_class.new(hosts, @options)
         expect(perf).to be_a described_class
@@ -34,8 +33,10 @@ module Beaker
       end
 
       it 'creates a new Perf object with multiple hosts' do
-        hosts = [make_host("myHost", @options), make_host("myOtherHost", @options)]
-        hosts.each { |host| host['platform'] = "centos-6-x86_64" }
+        hosts = [
+          make_host("myHost", @options.merge('platform' => 'centos-6-64')),
+          make_host("myOtherHost", @options.merge('platform' => 'centos-6-64')),
+        ]
         @my_logger.remove_destination(STDOUT)
         perf = described_class.new(hosts, @options)
         expect(perf).to be_a described_class
@@ -43,10 +44,11 @@ module Beaker
       end
 
       it 'creates a new Perf object with multiple hosts, SLES' do
-        hosts = [make_host("myHost", @options), make_host("myOtherHost", @options), make_host("myThirdHost", @options)]
-        hosts[0]['platform'] = "centos-6-x86_64"
-        hosts[1]['platform'] = "sles-11-x86_64"
-        hosts[2]['platform'] = "opensuse-15-x86_64"
+        hosts = [
+          make_host("myHost", @options.merge('platform' => 'centos-6-64')),
+          make_host("myOtherHost", @options.merge('platform' => 'sles-11-64')),
+          make_host("myThirdHost", @options.merge('platform' => 'opensuse-15-64')),
+        ]
         @my_logger.remove_destination(STDOUT)
         perf = described_class.new(hosts, @options)
         expect(perf).to be_a described_class
@@ -60,7 +62,6 @@ module Beaker
         @options[:collect_perf_data] = 'normal'
         @options[:log_level] = :debug
         @options[:color] = false
-        @hosts = [make_host("myHost", @options), make_host("myOtherHost", @options)]
         @my_io = StringIO.new
         @my_logger = Beaker::Logger.new(@options)
         @my_logger.add_destination(@my_io)
@@ -68,18 +69,21 @@ module Beaker
       end
 
       it "Does the Right Thing on Linux hosts" do
-        @hosts[0]['platform'] = "centos-6-x86_64"
+        hosts = [make_host("myHost", @options.merge('platform' => 'centos-6-64'))]
         @my_logger.remove_destination(STDOUT)
-        perf = described_class.new(@hosts, @options)
+        perf = described_class.new(hosts, @options)
         expect(perf).to be_a described_class
         perf.print_perf_info
-        expect(@my_io.string).to eq("Setup perf on host: myHost\nSetup perf on host: myOtherHost\nPerf (sysstat) not supported on host: myOtherHost\nGetting perf data for host: myHost\nGetting perf data for host: myOtherHost\nPerf (sysstat) not supported on host: myOtherHost\n")
+        expect(@my_io.string).to eq("Setup perf on host: myHost\nGetting perf data for host: myHost\n")
       end
 
       it "Does the Right Thing on non-Linux hosts" do
-        @hosts[0]['platform'] = "windows"
+        hosts = [
+          make_host("myHost", @options.merge('platform' => 'windows-11-64')),
+          make_host("myOtherHost", @options),
+        ]
         @my_logger.remove_destination(STDOUT)
-        perf = described_class.new(@hosts, @options)
+        perf = described_class.new(hosts, @options)
         expect(perf).to be_a described_class
         perf.print_perf_info
         expect(@my_io.string).to eq("Setup perf on host: myHost\nPerf (sysstat) not supported on host: myHost\nSetup perf on host: myOtherHost\nPerf (sysstat) not supported on host: myOtherHost\nGetting perf data for host: myHost\nPerf (sysstat) not supported on host: myHost\nGetting perf data for host: myOtherHost\nPerf (sysstat) not supported on host: myOtherHost\n")

--- a/spec/beaker/perf_spec.rb
+++ b/spec/beaker/perf_spec.rb
@@ -80,7 +80,7 @@ module Beaker
       it "Does the Right Thing on non-Linux hosts" do
         hosts = [
           make_host("myHost", @options.merge('platform' => 'windows-11-64')),
-          make_host("myOtherHost", @options),
+          make_host("myOtherHost", @options.merge('platform' => 'solaris-11-64')),
         ]
         @my_logger.remove_destination(STDOUT)
         perf = described_class.new(hosts, @options)

--- a/spec/beaker/shared/host_manager_spec.rb
+++ b/spec/beaker/shared/host_manager_spec.rb
@@ -11,7 +11,7 @@ module Beaker
       let(:logger)         { double('logger') }
       let(:host_handler)   { described_class }
       let(:spec_block)     { Proc.new { |arr| arr } }
-      let(:platform)       { @platform || 'unix' }
+      let(:platform)       { @platform || 'el-9-64' }
       let(:role0)          { "role0" }
       let(:role1)          { :role1 }
       let(:role2)          { :role2 }

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -24,7 +24,7 @@ module TestFileHelpers
 end
 
 module HostHelpers
-  HOST_DEFAULTS = { :platform => 'unix',
+  HOST_DEFAULTS = { :platform => 'el-9-64',
                     :roles => ['agent'],
                     :snapshot => 'snap',
                     :ip => 'default.ip.address',
@@ -90,6 +90,8 @@ module HostHelpers
 
   def make_host name, host_hash
     host_hash = Beaker::Options::OptionsHash.new.merge(HOST_DEFAULTS.merge(host_hash))
+
+    host_hash['platform'] = Beaker::Platform.new(host_hash['platform']) unless host_hash['platform'].is_a?(Beaker::Platform)
 
     host = Beaker::Host.create(name, host_hash, make_opts)
 


### PR DESCRIPTION
The regular option parser guarantees this and it sort of works because Beaker::Platform can behave as a string (since it inherits from it).  When you do want to use extended features, it fails.

This enhances the helper to guarantee it's the correct class instance. Then there are many changes to the tests to ensure a valid platform is passed in.

<del>Still incomplete and I wonder what we should do about the unix platform.</del>

<del>I'm also tempted to drop some platforms instead.</del>