### PR TITLE
PE-37978: Add 'amazon' to repo_filename method with tests for 4.x

### DIFF
--- a/lib/beaker/host/unix/file.rb
+++ b/lib/beaker/host/unix/file.rb
@@ -113,7 +113,7 @@ module Unix::File
     repo_filename = "pl-%s-%s-" % [ package_name, build_version ]
 
     case variant
-    when /fedora|el|redhat|centos|cisco_nexus|cisco_ios_xr|opensuse|sles/
+    when /amazon|fedora|el|redhat|centos|cisco_nexus|cisco_ios_xr|opensuse|sles/
       variant = 'el' if ['centos', 'redhat'].include?(variant)
 
       variant = 'redhatfips' if self['packaging_platform']&.include?('redhatfips')

--- a/spec/beaker/host/unix/file_spec.rb
+++ b/spec/beaker/host/unix/file_spec.rb
@@ -137,6 +137,14 @@ module Beaker
         expect( filename ).to be === correct
       end
 
+      it 'builds the filename correctly for amazon-based platforms' do
+        @platform = 'amazon-2023-x86_64'
+        allow( instance ).to receive( :is_pe? ).and_return(true)
+        filename = instance.repo_filename( 'pkg_name', 'pkg_version' )
+        correct = 'pl-pkg_name-pkg_version-amazon-2023-x86_64.repo'
+        expect( filename ).to be === correct
+      end
+
       it 'builds the filename correctly for debian-based platforms' do
         @platform = 'debian-8-x86_64'
         filename = instance.repo_filename( 'pkg_name', 'pkg_version10' )


### PR DESCRIPTION
Added 'amazon' support in #repo_filename method in lib/beaker/host/unix/file.rb.