### PR TITLE
Add extension parameter to parent tmpfile method signature

### DIFF
--- a/lib/beaker/host.rb
+++ b/lib/beaker/host.rb
@@ -544,7 +544,7 @@ module Beaker
       raise Beaker::Host::CommandFailure, result.error
     end
 
-    def tmpfile(name = '')
+    def tmpfile(name = '', extension = nil)
       raise NotImplementedError
     end
 


### PR DESCRIPTION
Even though this doesn't implement it, it's still good to use the same signature consistently.

Fixes: 37dd194f11eda4e39dd8e3d5f3cde5014e7e42e5 ("Support an extension to tmpfile")