### PR TITLE
Rubocop: Enable Naming/VariableNumber

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,9 +22,6 @@ Naming/MethodParameterName:
 Naming/PredicateName:
   Enabled: false
 
-Naming/VariableNumber:
-  Enabled: false
-
 RSpec/DescribeClass:
   Exclude:
     - acceptance/fixtures/module/spec/**/*.rb
@@ -49,3 +46,6 @@ RSpec/NestedGroups:
 
 Style:
   Enabled: false
+
+Naming/VariableNumber:
+  AllowedPatterns: ['x86_64']

--- a/acceptance/fixtures/module/spec/acceptance/demo_spec.rb
+++ b/acceptance/fixtures/module/spec/acceptance/demo_spec.rb
@@ -22,15 +22,15 @@ describe "my tests" do
   end
 
   it "is able to apply manifests" do
-    manifest_1 = "user {'foo':
+    manifest1 = "user {'foo':
           ensure => present,}"
-    manifest_2 = "user {'foo':
+    manifest2 = "user {'foo':
           ensure => absent,}"
-    manifest_3 = "user {'root':
+    manifest3 = "user {'root':
           ensure => present,}"
-    apply_manifest(manifest_1, :expect_changes => true)
-    apply_manifest(manifest_2, :expect_changes => true)
-    apply_manifest(manifest_3)
+    apply_manifest(manifest1, :expect_changes => true)
+    apply_manifest(manifest2, :expect_changes => true)
+    apply_manifest(manifest3)
   end
 
   describe service('sshd') do


### PR DESCRIPTION
I would like to clean up our .rubocop.yaml to follow our standards. I think enabling this cop makes sense, except for the `determine_if_x86_64` method. rubocop prefers `determine_if_x8664` but since `x86_64` is it's own name I disable the cop for this function.