### PR TITLE
.rspec: dont run with --fail-fast

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
 --format documentation
 --color
 --tty
---fail-fast


### PR DESCRIPTION
When this option is set, rspec will stop after the first failure. We don't have this enabled in any other project and I think it's useful to know if you've 20 errors or just one. And the CI runtime isn't that long, so IMO it's fine.