### PR TITLE
rubocop: Enable Naming/MethodParameterName

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ Naming/FileName:
     - acceptance/**/acceptance-options.rb
 
 Naming/MethodParameterName:
-  Enabled: false
+  MinNameLength: 1
 
 Naming/PredicateName:
   Enabled: false


### PR DESCRIPTION
The cop provides some benefits, but also wants that method args have three chars or more. We use one char a lot, but we can configure this.