### PR TITLE
non-systemd SLES: Readd support for restarting sshd via `rcsshd`

### DIFF
--- a/lib/beaker/host/unix/exec.rb
+++ b/lib/beaker/host/unix/exec.rb
@@ -284,6 +284,8 @@ module Unix::Exec
       exec(Beaker::Command.new("svcadm restart svc:/network/ssh:default"))
     when /(free|open)bsd/
       exec(Beaker::Command.new("sudo /etc/rc.d/sshd restart"))
+    when /opensuse|sles/
+      exec(Beaker::Command.new("/usr/sbin/rcsshd restart"))
     else
       exec(Beaker::Command.new("systemctl restart sshd.service"))
     end


### PR DESCRIPTION
This is a followup of 3fb9a1bd857d21995d15d6cf876ce5c64fda0bb0