### PR TITLE
Add package logic for Amazon Linux 2

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -85,7 +85,7 @@ module Unix::Pkg
     when /amazon-2023|el-(8|9|1[0-9])|fedora/
       name = "#{name}-#{version}" if version
       execute("dnf -y #{cmdline_args} install #{name}", opts)
-    when /centos|redhat|el-[1-7]-/
+    when /amazon-7|centos|redhat|el-[1-7]-/
       name = "#{name}-#{version}" if version
       execute("yum -y #{cmdline_args} install #{name}", opts)
     when /ubuntu|debian/
@@ -167,7 +167,7 @@ module Unix::Pkg
       execute("zypper --non-interactive rm #{name}", opts)
     when /amazon-2023|el-(8|9|1[0-9])|fedora/
       execute("dnf -y #{cmdline_args} remove #{name}", opts)
-    when /centos|redhat|el-[1-7]-/
+    when /amazon-7|centos|redhat|el-[1-7]-/
       execute("yum -y #{cmdline_args} remove #{name}", opts)
     when /ubuntu|debian/
       execute("apt-get purge #{cmdline_args} -y #{name}", opts)

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -161,6 +161,14 @@ module Beaker
         expect(instance.install_package(pkg)).to eq "hello"
       end
 
+      it "uses yum on amazon linux 2" do
+        @opts = { 'platform' => "amazon-7-is-me" }
+        pkg = 'amazon_package'
+        expect(Beaker::Command).to receive(:new).with("yum -y  install #{pkg}", [], { :prepend_cmds => nil, :cmdexe => false }).and_return('')
+        expect(instance).to receive(:exec).with('', {}).and_return(generate_result("hello", { :exit_code => 0 }))
+        expect(instance.install_package(pkg)).to eq "hello"
+      end
+
       it "uses pacman on archlinux" do
         @opts = { 'platform' => 'archlinux-is-me' }
         pkg = 'archlinux_package'
@@ -269,6 +277,14 @@ module Beaker
           expect(instance).to receive(:execute).with(/^yum.*#{package_file}$/)
           instance.install_local_package(package_file)
         end
+      end
+
+      it 'Amazon Linux 2 uses yum' do
+        @platform = platform
+        @version = '7'
+        package_file = 'test_123.yay'
+        expect(instance).to receive(:execute).with(/^yum.*#{package_file}$/)
+        instance.install_local_package(package_file)
       end
 
       it 'Centos & EL: uses yum' do


### PR DESCRIPTION
This commit adds logic for Amazon Linux 2 to Beaker's install_ and uninstall_package methods. (Note: AL2 is referred to in Vanagon and ABS as Amazon Linux 7, in reference to the assumed compatibility with Red Hat Enterprise Linux 7.)