### PR TITLE
Add Amazon 2

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -85,7 +85,7 @@ module Unix::Pkg
     when /amazon-2023|el-(8|9|1[0-9])|fedora/
       name = "#{name}-#{version}" if version
       execute("dnf -y #{cmdline_args} install #{name}", opts)
-    when /amazon-7|centos|redhat|el-[1-7]-/
+    when /amazon-(2|7)|centos|redhat|el-[1-7]-/
       name = "#{name}-#{version}" if version
       execute("yum -y #{cmdline_args} install #{name}", opts)
     when /ubuntu|debian/
@@ -167,7 +167,7 @@ module Unix::Pkg
       execute("zypper --non-interactive rm #{name}", opts)
     when /amazon-2023|el-(8|9|1[0-9])|fedora/
       execute("dnf -y #{cmdline_args} remove #{name}", opts)
-    when /amazon-7|centos|redhat|el-[1-7]-/
+    when /amazon-(2|7)|centos|redhat|el-[1-7]-/
       execute("yum -y #{cmdline_args} remove #{name}", opts)
     when /ubuntu|debian/
       execute("apt-get purge #{cmdline_args} -y #{name}", opts)

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -161,8 +161,16 @@ module Beaker
         expect(instance.install_package(pkg)).to eq "hello"
       end
 
-      it "uses yum on amazon linux 2" do
+      it "uses yum on misnamed amazon linux 7" do
         @opts = { 'platform' => "amazon-7-is-me" }
+        pkg = 'amazon_package'
+        expect(Beaker::Command).to receive(:new).with("yum -y  install #{pkg}", [], { :prepend_cmds => nil, :cmdexe => false }).and_return('')
+        expect(instance).to receive(:exec).with('', {}).and_return(generate_result("hello", { :exit_code => 0 }))
+        expect(instance.install_package(pkg)).to eq "hello"
+      end
+
+      it "uses yum on amazon linux 2" do
+        @opts = { 'platform' => "amazon-2-is-me" }
         pkg = 'amazon_package'
         expect(Beaker::Command).to receive(:new).with("yum -y  install #{pkg}", [], { :prepend_cmds => nil, :cmdexe => false }).and_return('')
         expect(instance).to receive(:exec).with('', {}).and_return(generate_result("hello", { :exit_code => 0 }))
@@ -281,7 +289,7 @@ module Beaker
 
       it 'Amazon Linux 2 uses yum' do
         @platform = platform
-        @version = '7'
+        @version = '2'
         package_file = 'test_123.yay'
         expect(instance).to receive(:execute).with(/^yum.*#{package_file}$/)
         instance.install_local_package(package_file)

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -124,6 +124,7 @@ module PlatformHelpers
 
   REDHATPLATFORMS = %w[
     amazon-2023
+    amazon-2
     fedora
     el-
     centos


### PR DESCRIPTION
Copies Amazon 7 to 2, as the former is an implementation detail and the latter is the actual OS version: https://aws.amazon.com/amazon-linux-2

I was able to run facter beaker tests with this PR and https://github.com/voxpupuli/beaker-hostgenerator/pull/372

```
❯ env | grep BEAKER                                                                                     
BEAKER_VERSION=https://github.com/voxpupuli/beaker#amazon2
BEAKER_PUPPET_VERSION=~> 4.0
BEAKER_HOSTGENERATOR_VERSION=https://github.com/voxpupuli/beaker-hostgenerator#amazon2
❯ cd ~/work/facter/acceptance
❯ bundle update
❯ env SHA=c6c5de5b1457d0cad36bcbb0ee94ec3c3486014d HOSTS=amazon2-AARCH64a bundle exec rake ci:test:setup
...
❯ bundle exec beaker exec tests
... SNIP...
      - Host Configuration Summary -


              - Test Case Summary for suite 'tests' -
       Total Suite Time: 500.02 seconds
      Average Test Time: 2.96 seconds
              Attempted: 169
                 Passed: 147
                 Failed: 0
                Errored: 0
                Skipped: 22
                Pending: 0
                  Total: 169

      - Specific Test Case Status -
        
Failed Tests Cases:
Errored Tests Cases:
Skipped Tests Cases:
  Test Case tests/api/value/core_and_custom.rb 
  Test Case tests/api/value/core_and_custom_overwrite.rb 
  Test Case tests/api/value/core_fact.rb 
  Test Case tests/api/value/custom_fact_in_different_file.rb 
  Test Case tests/api/value/custom_fact_in_same_file_as_fact_name.rb 
  Test Case tests/api/value/env_fact.rb 
  Test Case tests/api/value/external_fact.rb 
  Test Case tests/api/value/non_existent_fact.rb 
  Test Case tests/custom_facts/expand_command.rb 
  Test Case tests/custom_facts/not_expand_command.rb 
  Test Case tests/custom_facts/using_win32ole_should_not_hang.rb 
  Test Case tests/custom_facts/windows_not_expand_command.rb 
  Test Case tests/facts/mountpoints_fact.rb 
  Test Case tests/facts/nim_type.rb 
  Test Case tests/facts/operatingsystem_detection_after_clear_on_ubuntu.rb 
  Test Case tests/facts/osx_numeric_hostname.rb 
  Test Case tests/facts/validate_file_system_size_bytes.rb 
  Test Case tests/facts/windows_os.rb 
  Test Case tests/options/config_file/ttls/cached_custom_group_core_custom_facts.rb 
  Test Case tests/options/config_file/ttls_cached_facts_that_are_empty_return_an_empty_value.rb 
  Test Case tests/options/config_file/ttls_external_facts_in_custom_groups.rb 
  Test Case tests/options/puppet_facts.rb 
Pending Tests Cases:

```