### PR TITLE
Debian: Replace apt-get with apt for updates

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -62,7 +62,8 @@ module Unix::Pkg
     return unless /debian|ubuntu/.match?(self['platform'])
     return unless @apt_needs_update
 
-    execute("apt-get update")
+    # -qq: Only output errors to stdout
+    execute("apt-get update -qq")
     @apt_needs_update = false
   end
 
@@ -263,7 +264,8 @@ module Unix::Pkg
       execute("zypper --non-interactive --no-gpg-checks in #{onhost_package_file}")
     when /^(debian|ubuntu)$/
       execute("dpkg -i --force-all #{onhost_package_file}")
-      execute("apt-get update")
+      # -qq: Only output errors to stdout
+      execute("apt-get update -qq")
     when /^solaris$/
       self.solaris_install_local_package(onhost_package_file, onhost_copy_dir)
     when /^osx$/

--- a/lib/beaker/host_prebuilt_steps.rb
+++ b/lib/beaker/host_prebuilt_steps.rb
@@ -204,7 +204,8 @@ module Beaker
     # @param [Host, Array<Host>] hosts One or more hosts to act upon
     def apt_get_update hosts
       block_on hosts do |host|
-        host.exec(Command.new("apt-get update")) if /ubuntu|debian/.match?(host[:platform])
+        # -qq: Only output errors to stdout
+        host.exec(Command.new("apt-get update -qq")) if /ubuntu|debian/.match?(host[:platform])
       end
     end
 

--- a/spec/beaker/host/unix/pkg_spec.rb
+++ b/spec/beaker/host/unix/pkg_spec.rb
@@ -128,7 +128,7 @@ module Beaker
         it "calls update for #{platform}" do
           @opts = { 'platform' => platform }
           instance.instance_variable_set(:@apt_needs_update, true)
-          expect(instance).to receive('execute').with("apt-get update")
+          expect(instance).to receive('execute').with("apt-get update -qq")
           expect { instance.update_apt_if_needed }.not_to raise_error
         end
       end
@@ -309,7 +309,7 @@ module Beaker
         %w[debian ubuntu].each do |platform|
           @platform = platform
           expect(instance).to receive(:execute).with(/^dpkg.*#{package_file}$/)
-          expect(instance).to receive(:execute).with('apt-get update')
+          expect(instance).to receive(:execute).with('apt-get update -qq')
           instance.install_local_package(package_file)
         end
       end

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -227,7 +227,7 @@ describe Beaker do
     it "can perform apt-get on ubuntu hosts" do
       host = make_host('testhost', { :platform => 'ubuntu' })
 
-      expect(Beaker::Command).to receive(:new).with("apt-get update").once
+      expect(Beaker::Command).to receive(:new).with("apt-get update -qq").once
 
       subject.apt_get_update(host)
     end
@@ -235,7 +235,7 @@ describe Beaker do
     it "can perform apt-get on debian hosts" do
       host = make_host('testhost', { :platform => 'debian' })
 
-      expect(Beaker::Command).to receive(:new).with("apt-get update").once
+      expect(Beaker::Command).to receive(:new).with("apt-get update -qq").once
 
       subject.apt_get_update(host)
     end


### PR DESCRIPTION
This replaces the old `apt-get update` with the newer `apt update`. This works on all modern Debian versions we support. Also `-qq` was added, to only output errors. This makes the beaker run a bit more readable.