### PR TITLE
Arch Linux: Generate keyring before installing packages

### DIFF
--- a/lib/beaker/host/unix/pkg.rb
+++ b/lib/beaker/host/unix/pkg.rb
@@ -74,6 +74,10 @@ module Unix::Pkg
     return unless self['platform'].include?('archlinux')
     return unless @pacman_needs_update
 
+    # creates a GPG key + local keyring
+    execute("pacman-key --init")
+    # `archlinux-keyring` contains GPG keys that will be imported into the local keyring
+    # used to verify package signatures
     execute("pacman --sync --noconfirm --noprogressbar --refresh archlinux-keyring")
     execute("pacman --sync --noconfirm --noprogressbar --refresh --sysupgrade --ignore linux --ignore linux-docs --ignore linux-headers")
     @pacman_needs_update = false


### PR DESCRIPTION
This will ensure we've a local keyring available. That's a requirement to instal and import keys. According to
https://gitlab.archlinux.org/archlinux/archlinux-docker#principles, the container images don't ship a local keyring by default.