### PR TITLE
platform: don't install `curl-minimal` on EL family

### DIFF
--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -118,7 +118,7 @@ module Beaker
     def base_packages
       case @variant
       when 'el'
-        @version.to_i >= 8 ? ['curl-minimal', 'iputils'] : %w[curl]
+        @version.to_i >= 8 ? ['iputils'] : %w[curl]
       when 'debian'
         %w[curl lsb-release]
       when 'freebsd'
@@ -128,7 +128,7 @@ module Beaker
       when 'archlinux'
         %w[curl net-tools openssh]
       when 'amazon', 'fedora'
-        ['curl-minimal', 'iputils']
+        ['iputils']
       when 'aix', 'osx', 'windows'
         []
       else

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -276,7 +276,7 @@ describe Beaker do
     it "can validate el-9 hosts" do
       host = make_host('host', { :platform => 'el-9-64' })
 
-      ['curl-minimal', 'iputils'].each do |pkg|
+      ['iputils'].each do |pkg|
         expect(host).to receive(:check_for_package).with(pkg).once.and_return(false)
         expect(host).to receive(:install_package).with(pkg).once
       end
@@ -321,7 +321,7 @@ describe Beaker do
     it "can validate RHEL8 hosts" do
       host = make_host('host', { :platform => 'el-8-64' })
 
-      ['curl-minimal', 'iputils'].each do |pkg|
+      ['iputils'].each do |pkg|
         expect(host).to receive(:check_for_package).with(pkg).once.and_return(false)
         expect(host).to receive(:install_package).with(pkg).once
       end
@@ -332,7 +332,7 @@ describe Beaker do
     it "can validate Fedora hosts" do
       host = make_host('host', { :platform => 'fedora-32-x86_64' })
 
-      ['curl-minimal', 'iputils'].each do |pkg|
+      ['iputils'].each do |pkg|
         expect(host).to receive(:check_for_package).with(pkg).once.and_return(false)
         expect(host).to receive(:install_package).with(pkg).once
       end
@@ -343,7 +343,7 @@ describe Beaker do
     it "can validate Amazon hosts" do
       host = make_host('host', { :platform => 'amazon-2023-x86_64' })
 
-      ['curl-minimal', 'iputils'].each do |pkg|
+      ['iputils'].each do |pkg|
         expect(host).to receive(:check_for_package).with(pkg).once.and_return(false)
         expect(host).to receive(:install_package).with(pkg).once
       end


### PR DESCRIPTION
`curl-minimal` was mistakenly added in commit 18e6e2292aeed5557c6a85e45ba86365ca43d6f6. Attempting to install it on EL 8 and newer causes errors because there is no such package.

`curl` is installed by default. See
https://fedoraproject.org/wiki/Changes/CurlMinimal_as_Default and #1854,
for example.