### PR TITLE
platform: Debian: don't install apt-transport-https

### DIFF
--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -120,7 +120,7 @@ module Beaker
       when 'el'
         @version.to_i >= 8 ? ['curl-minimal', 'iputils'] : %w[curl]
       when 'debian'
-        %w[curl lsb-release apt-transport-https]
+        %w[curl lsb-release]
       when 'freebsd'
         %w[curl perl5|perl]
       when 'solaris'


### PR DESCRIPTION
This package is not needed and does nothing on the versions of
Debian-family operating systems that we support (only non-EOL versions;
see #1871, for other removal of EOL Debian-family code).
