### PR TITLE
Changes to add powershell commands as wmic is deprecated in windows 2025

### DIFF
--- a/lib/beaker/host/windows/group.rb
+++ b/lib/beaker/host/windows/group.rb
@@ -14,6 +14,20 @@ module Windows::Group
     end
   end
 
+  # using powershell commands as wmic is deprecated in windows 2025
+  def group_list_using_powershell
+    execute('cmd /c echo "" | powershell.exe "Get-LocalGroup | Select-Object -ExpandProperty Name"') do |result|
+      groups = []
+      result.stdout.each_line do |line|
+        groups << line.strip or next
+      end
+
+      yield result if block_given?
+
+      groups
+    end
+  end
+
   def group_get(name)
     execute("net localgroup \"#{name}\"") do |result|
       fail_test "failed to get group #{name}" if result.exit_code != 0

--- a/lib/beaker/host/windows/user.rb
+++ b/lib/beaker/host/windows/user.rb
@@ -14,6 +14,20 @@ module Windows::User
     end
   end
 
+  # using powershell commands as wmic is deprecated in windows 2025
+  def user_list_using_powershell
+    execute('cmd /c echo "" | powershell.exe "Get-LocalUser | Select-Object -ExpandProperty Name"') do |result|
+      users = []
+      result.stdout.each_line do |line|
+        users << line.strip or next
+      end
+
+      yield result if block_given?
+
+      users
+    end
+  end
+
   def user_get(name)
     execute("net user \"#{name}\"") do |result|
       fail_test "failed to get user #{name}" if result.exit_code != 0

--- a/spec/beaker/host/windows/group_spec.rb
+++ b/spec/beaker/host/windows/group_spec.rb
@@ -7,47 +7,66 @@ module Beaker
     end
 
     let(:instance) { WindowsGroupTest.new }
-    let(:result) { double(:result, :stdout => group_list_output) }
-    let(:group_list_output) do
-      <<~EOS
-        Name=Foo
+
+    context "Group list" do
+      let(:result) { double(:result, :stdout => group_list_output) }
+      let(:group_list_output) do
+        <<~EOS
+          Name=Foo
 
 
-        Name=Bar6
+          Name=Bar6
 
 
-      EOS
+        EOS
+      end
+
+      def add_group(group_name)
+        group_list_output << <<~EOS
+          Name=#{group_name}
+
+
+        EOS
+      end
+
+      before do
+        expect(instance).to receive(:execute).with(/wmic group where/).and_yield(result)
+      end
+
+      it "gets a group_list" do
+        expect(instance.group_list).to eql(%w[Foo Bar6])
+      end
+
+      it "gets groups with spaces" do
+        add_group("With Spaces")
+        expect(instance.group_list).to eql(["Foo", "Bar6", "With Spaces"])
+      end
+
+      it "gets groups with dashes" do
+        add_group("With-Dashes")
+        expect(instance.group_list).to eql(%w[Foo Bar6 With-Dashes])
+      end
+
+      it "gets groups with underscores" do
+        add_group("With_Underscores")
+        expect(instance.group_list).to eql(%w[Foo Bar6 With_Underscores])
+      end
     end
 
-    def add_group(group_name)
-      group_list_output << <<~EOS
-        Name=#{group_name}
+    context "Group list using powershell" do
+      let(:group_list_using_powershell_output) do
+        <<~EOS
+          Foo1
+          Bar5
+        EOS
+      end
 
+      let(:result1) { double(:result1, :stdout => group_list_using_powershell_output) }
 
-      EOS
-    end
-
-    before do
-      expect(instance).to receive(:execute).with(/wmic group where/).and_yield(result)
-    end
-
-    it "gets a group_list" do
-      expect(instance.group_list).to eql(%w[Foo Bar6])
-    end
-
-    it "gets groups with spaces" do
-      add_group("With Spaces")
-      expect(instance.group_list).to eql(["Foo", "Bar6", "With Spaces"])
-    end
-
-    it "gets groups with dashes" do
-      add_group("With-Dashes")
-      expect(instance.group_list).to eql(%w[Foo Bar6 With-Dashes])
-    end
-
-    it "gets groups with underscores" do
-      add_group("With_Underscores")
-      expect(instance.group_list).to eql(%w[Foo Bar6 With_Underscores])
+      it "gets a group_list using powershell" do
+        expect(instance).to receive(:execute).with(/powershell.exe "Get-LocalGroup | Select-Object -ExpandProperty Name/).and_yield(result1)
+        expect(instance.group_list_using_powershell).to eql(%w[Foo1 Bar5])
+      end
     end
   end
 end

--- a/spec/beaker/host/windows/user_spec.rb
+++ b/spec/beaker/host/windows/user_spec.rb
@@ -5,48 +5,50 @@ class WindowsUserTest
 end
 
 describe WindowsUserTest do
-  let(:wmic_output) do
-    <<~EOS
-      Name=Administrator
-
-
-
-
-
-      Name=bob foo
-
-
-
-
-
-      Name=bob-dash
-
-
-
-
-
-      Name=bob.foo
-
-
-
-
-
-      Name=cyg_server
-
-
-
-
-
-
-
-
-    EOS
-  end
-  let(:command) { 'cmd /c echo "" | wmic useraccount where localaccount="true" get name /format:value' }
   let(:host) { double.as_null_object }
   let(:result) { Beaker::Result.new(host, command) }
 
   describe '#user_list' do
+    let(:command) { 'cmd /c echo "" | wmic useraccount where localaccount="true" get name /format:value' }
+
+    let(:wmic_output) do
+      <<~EOS
+        Name=Administrator
+
+
+
+
+
+        Name=bob foo
+
+
+
+
+
+        Name=bob-dash
+
+
+
+
+
+        Name=bob.foo
+
+
+
+
+
+        Name=cyg_server
+
+
+
+
+
+
+
+
+      EOS
+    end
+
     it 'returns user names list correctly' do
       result.stdout = wmic_output
       expect(subject).to receive(:execute).with(command).and_yield(result)
@@ -59,6 +61,22 @@ describe WindowsUserTest do
       subject.user_list do |result|
         expect(result.stdout).to be === wmic_output
       end
+    end
+  end
+
+  describe "#user_list_using_powershell" do
+    let(:command) { 'cmd /c echo "" | powershell.exe "Get-LocalUser | Select-Object -ExpandProperty Name"' }
+    let(:user_list_using_powershell_output) do
+      <<~EOS
+        Administrator
+        WDAGUtilityAccount
+      EOS
+    end
+
+    it 'returns user names list correctly' do
+      result.stdout = user_list_using_powershell_output
+      expect(subject).to receive(:execute).with(command).and_yield(result)
+      expect(subject.user_list_using_powershell).to be === ["Administrator", "WDAGUtilityAccount"]
     end
   end
 end


### PR DESCRIPTION
With this PR trying to use powershell commands for `group_list` and `user_list` methods for windows as wmic is deprecated with windows 2025.