### PR TITLE
Fix macOS package installation when DMG content differs from filename

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -272,6 +272,7 @@ RSpec/SpecFilePathFormat:
     - 'spec/beaker/dsl/wrappers_spec.rb'
     - 'spec/beaker/host/mac/group_spec.rb'
     - 'spec/beaker/host/mac/user_spec.rb'
+    - 'spec/beaker/host/mac/pkg_spec.rb'
     - 'spec/beaker/host/pswindows/user_spec.rb'
     - 'spec/beaker/host/windows/user_spec.rb'
     - 'spec/beaker/host_prebuilt_steps_spec.rb'

--- a/lib/beaker/host/mac/pkg.rb
+++ b/lib/beaker/host/mac/pkg.rb
@@ -18,7 +18,10 @@ module Mac::Pkg
   # @param [String] pkg_base      The base name of the directory that the dmg
   #                               attaches to under `/Volumes`
   # @param [String] pkg_name      The name of the package file that should be
-  #                               used by the installer
+  #                               used by the installer. If the specified
+  #                               package is not found, a wildcard search will be
+  #                               performed to locate and install the first `.pkg`
+  #                               file in the volume.
   # @example: Install vagrant from URL
   #   mymachost.generic_install_dmg('https://releases.hashicorp.com/vagrant/1.8.4/vagrant_1.8.4.dmg', 'Vagrant', 'Vagrant.pkg')
   def generic_install_dmg(dmg_file, pkg_base, pkg_name)
@@ -36,7 +39,7 @@ module Mac::Pkg
         execute("installer -pkg #{specific_pkg_path} -target /")
       else
         # else find and install the first *.pkg file in the volume
-        execute(<<~SCRIPT
+        execute <<~SCRIPT
           found=0
           for pkg in /Volumes/#{pkg_base}/*.pkg; do
             if [ -f "$pkg" ]; then
@@ -53,7 +56,6 @@ module Mac::Pkg
             exit 1
           fi
         SCRIPT
-               )
       end
     end
   end

--- a/lib/beaker/host/mac/pkg.rb
+++ b/lib/beaker/host/mac/pkg.rb
@@ -40,18 +40,12 @@ module Mac::Pkg
       else
         # else find and install the first *.pkg file in the volume
         execute <<~SCRIPT
-          found=0
-          for pkg in /Volumes/#{pkg_base}/*.pkg; do
-            if [ -f "$pkg" ]; then
-              echo "Installing $pkg"
-              installer -pkg "$pkg" -target /
-              found=1
-              break  # Only install the first package found
-            fi
-          done
-
-          # Return non-zero exit code if no packages were found
-          if [ $found -eq 0 ]; then
+          # find the first .pkg file in the mounted volume
+          pkg=$(find /Volumes/#{pkg_base} -name "*.pkg" -type f -print -quit)
+          if [ -n "$pkg" ]; then
+            echo "Installing $pkg"
+            installer -pkg "$pkg" -target /
+          else
             echo "ERROR: No .pkg files found in /Volumes/#{pkg_base}/"
             exit 1
           fi

--- a/spec/beaker/host/mac/pkg_spec.rb
+++ b/spec/beaker/host/mac/pkg_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+class MacPkgTest
+  include Mac::Pkg
+  # CommandFactory is included in Mac::Pkg to provide us with the execute method
+  include Beaker::CommandFactory
+
+  def initialize
+    @logger = RSpec::Mocks::Double.new('logger').as_null_object
+
+    # Set up the test host to be used
+    @hostname = "mac.test.com"
+    @options = {}
+    @test_host = Beaker::Host.create(@hostname, @options, {})
+  end
+
+  def logger
+    @logger
+  end
+end
+
+describe MacPkgTest do
+  let(:host) { described_class.new }
+  let(:result_success) { Beaker::Result.new('host', 'cmd') }
+  let(:result_failure) { Beaker::Result.new('host', 'cmd') }
+  let(:dmg_file) { 'test-package.dmg' }
+  let(:pkg_base) { 'test-package' }
+  let(:pkg_name) { 'test-package.pkg' }
+
+  before do
+    result_success.exit_code = 0
+    result_failure.exit_code = 1
+  end
+
+  describe '#generic_install_dmg' do
+    context 'when the DMG file does not exist' do
+      it 'curls the DMG file' do
+        allow(host).to receive(:execute).with("test -f #{dmg_file}", { :accept_all_exit_codes => true }).and_yield(result_failure)
+        expect(host).to receive(:execute).with("curl -O #{dmg_file}")
+        allow(host).to receive(:execute).with("hdiutil attach test-package.dmg")
+        allow(host).to receive(:execute).with("test -f /Volumes/#{pkg_base}/#{pkg_name}", { :accept_all_exit_codes => true }).and_yield(result_success)
+        allow(host).to receive(:execute).with("installer -pkg /Volumes/#{pkg_base}/#{pkg_name} -target /")
+
+        host.generic_install_dmg(dmg_file, pkg_base, pkg_name)
+      end
+    end
+
+    context 'when the specific package exists in the DMG' do
+      it 'installs the specific package' do
+        allow(host).to receive(:execute).with("test -f #{dmg_file}", { :accept_all_exit_codes => true }).and_yield(result_success)
+        allow(host).to receive(:execute).with("hdiutil attach test-package.dmg")
+        allow(host).to receive(:execute).with("test -f /Volumes/#{pkg_base}/#{pkg_name}", { :accept_all_exit_codes => true }).and_yield(result_success)
+        expect(host).to receive(:execute).with("installer -pkg /Volumes/#{pkg_base}/#{pkg_name} -target /")
+
+        host.generic_install_dmg(dmg_file, pkg_base, pkg_name)
+      end
+    end
+
+    context 'when the included pkg has a different name from the dmg' do
+      it 'searches for and installs the first package found' do
+        allow(host).to receive(:execute).with("test -f #{dmg_file}", { :accept_all_exit_codes => true }).and_yield(result_success)
+        allow(host).to receive(:execute).with("hdiutil attach test-package.dmg")
+        allow(host).to receive(:execute).with("test -f /Volumes/#{pkg_base}/#{pkg_name}", { :accept_all_exit_codes => true }).and_yield(result_failure)
+
+        # This is a bit complex as we're testing the heredoc script execution
+        # We're expecting the script to be executed and are not validating its exact content
+        expect(host).to receive(:execute).with(a_string_including("for pkg in /Volumes/#{pkg_base}/*.pkg"))
+
+        host.generic_install_dmg(dmg_file, pkg_base, pkg_name)
+      end
+    end
+  end
+
+  describe '#install_package' do
+    it 'calls generic_install_dmg with the correct arguments' do
+      expect(host).to receive(:generic_install_dmg).with("package.dmg", "package", "package.pkg")
+      host.install_package("package")
+    end
+
+    it 'strips the .dmg extension if present' do
+      expect(host).to receive(:generic_install_dmg).with("package.dmg", "package", "package.pkg")
+      host.install_package("package.dmg")
+    end
+  end
+end

--- a/spec/beaker/host/mac/pkg_spec.rb
+++ b/spec/beaker/host/mac/pkg_spec.rb
@@ -64,7 +64,7 @@ describe MacPkgTest do
 
         # This is a bit complex as we're testing the heredoc script execution
         # We're expecting the script to be executed and are not validating its exact content
-        expect(host).to receive(:execute).with(a_string_including("for pkg in /Volumes/#{pkg_base}/*.pkg"))
+        expect(host).to receive(:execute).with(a_string_including("find /Volumes/#{pkg_base} -name \"*.pkg\" -type f -print -quit"))
 
         host.generic_install_dmg(dmg_file, pkg_base, pkg_name)
       end


### PR DESCRIPTION
## Problem

The current macOS package installation code assumes that

* **(1)** the `name` input to `Mac::Pkg.install_package(name,...)` will be a filename without an extension
* **(2)** the `*.pkg` file inside a DMG will have the same base name as the DMG itself.

**(1)** caused failures in our CI because the subsequent code was mismatching some of the extensions so making the code look for a non-existent file/directory.
**(2)** caused failures because some of our DMGs do not have a `*pkg` name with the same basename as the `*.dmg`

For example:

```bash
# mount the dmg before installation
utter-suzerain:~ root# hdiutil attach puppet-bolt-4.0.0-1.osx14.dmg 
Checksumming Protective Master Boot Record (MBR : 0)…
...
...
utter-suzerain:~ root#     

# notice internal *.pkg has a different basename
utter-suzerain:~ root# ls /Volumes/puppet-bolt-4.0.0-1.osx14/
puppet-bolt-4.0.0-1-installer.pkg
utter-suzerain:~ root# 
```

## Solution

This PR makes the following changes:

1. Strips any `.dmg` extension--if it exists--from the package `name` input to `Mac::Pkg.install_package(name,...)`
2. ONLYIF `#{pkg_name}` doesn't exist, then do a wildcard search for the pkg name.  If nothing is found even with this, then error out.

These changes ensure we can find and install the correct package regardless of naming differences between the DMG file and its contents.

# Testing

* Added new `spec/beaker/host/mac/pkg_spec.rb`
* Manually tested the PR condition: the pkg name is different from the dmg filename (current PR allows this)
* Manually tested backwards compatibility: (1) the pkg name is the same as dmg name; (2) the pkg doesn't exist at all within the dmg
