### PR TITLE
Fix Debian 13 NTP setup by using chrony

### DIFF
--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -108,6 +108,8 @@ module Beaker
         true
       when 'el'
         @version.to_i >= 8
+      when 'debian'
+        @version.to_i >= 13
       else
         false
       end


### PR DESCRIPTION
This is the error Debian 13 gives:

{"stream":"Package ntpdate is not available, but is referred to by another package.\nThis may mean that the package is missing, has been obsoleted, or\nis only available from another source\nHowever the following packages replace it:\n  ntpsec-ntpdate\n\n"}

For Debian 13+, use chrony