### PR TITLE
Stop Logger#convert allocating a String per character

### DIFF
--- a/lib/beaker/logger.rb
+++ b/lib/beaker/logger.rb
@@ -197,7 +197,7 @@ module Beaker
       else
         # Remove invalid and undefined UTF-8 character encodings
         string = string.to_s.dup.force_encoding('UTF-8')
-        return string.to_s.chars.select { |i| i.valid_encoding? }.join
+        string.scrub('')
       end
     end
 

--- a/spec/beaker/logger_spec.rb
+++ b/spec/beaker/logger_spec.rb
@@ -24,6 +24,24 @@ module Beaker
         valid_utf8.freeze
         expect(logger.convert(valid_utf8)).to be === valid_utf8
       end
+
+      it 'leaves the string it was given alone' do
+        expect(logger.convert(invalid_utf8)).not_to equal(invalid_utf8)
+        expect(invalid_utf8.bytes).to include(0xAD)
+      end
+
+      it 'converts each item of an array' do
+        expect(logger.convert([valid_utf8, invalid_utf8])).to eq([valid_utf8, valid_utf8])
+      end
+
+      it 'converts arrays of arrays' do
+        expect(logger.convert([[invalid_utf8], valid_utf8])).to eq([[valid_utf8], valid_utf8])
+      end
+
+      it 'converts anything that can describe itself' do
+        expect(logger.convert(42)).to eq('42')
+        expect(logger.convert(nil)).to eq('')
+      end
     end
 
     describe '#generate_dated_log_folder' do


### PR DESCRIPTION
`Logger#convert` removed invalid UTF-8 with
`chars.select { |i| i.valid_encoding? }.join`, which allocates a `String`
object for every character it is handed. `String#scrub` is the same
operation in a single pass.

This is far cheaper per call than the equivalent in `Result#convert`,
because the logger sees host output in net-ssh sized chunks rather than
whole commands, so only a chunk's worth of objects is ever live at once
and the heap does not balloon. It still came to 7.6 million objects over
a 7.6MB run.

Measured over the console output of a real PE upgrade run, in 16KB chunks:

|                   |    before |   after |
| ----------------- | --------: | ------: |
| objects allocated | 7,647,447 |   2,812 |
| time              |     0.91s |   0.00s |
| peak RSS          |   30.7 MB | 29.2 MB |
| permanent heap    |    1.4 MB |  0.2 MB |

### No behaviour change

Output is identical across all 1,112,064 unicode codepoints, and for nil,
integers, symbols, frozen strings, subclasses of `String`, arrays and
arrays of arrays. The one difference is that an empty string comes back
tagged UTF-8 rather than US-ASCII, which is what the non-empty ascii case
already did.

Every spec in `logger_spec.rb`, including the four added here, passes
against the unmodified implementation as well.

The added specs cover the paths this touches that had no coverage: array,
nested array, non-`String`, nil, and that the caller's string is not
retagged or mutated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)