### PR TITLE
Stop escape_invalid_xml_chars allocating per character

### DIFF
--- a/lib/beaker/logger_junit.rb
+++ b/lib/beaker/logger_junit.rb
@@ -120,21 +120,25 @@ module Beaker
       self.escape_invalid_xml_chars(Logger.strip_color_codes(string))
     end
 
+    # Every character {is_valid_xml} rejects, as one pattern. Note that this
+    # tracks that method rather than the specification it cites: #xD is absent
+    # from both, and both take the last range as 0x100000 rather than the
+    # 0x10000 the specification gives. Changing either would change the
+    # contents of every junit report, so they are left alone here and the specs
+    # walk the whole range to keep the two in step.
+    INVALID_XML_CHARS = /[^\u{9}\u{A}\u{20}-\u{D7FF}\u{E000}-\u{FFFD}\u{100000}-\u{10FFFF}]/
+
     # Escape invalid XML UTF-8 codes from provided string, see http://www.w3.org/TR/xml/#charsets for valid
     # character specification
     # @param [String] string The string to remove invalid codes from
     # @return [String] Properly escaped string
     def self.escape_invalid_xml_chars string
-      escaped_string = ""
-      string.chars.each do |i|
-        char_as_codestring = i.unpack("U*").join
-        escaped_string << if self.is_valid_xml(char_as_codestring.to_i)
-                            i
-                          else
-                            "\\#{char_as_codestring}"
-                          end
-      end
-      escaped_string
+      # This walked the string a character at a time, unpacking each one into
+      # an array and joining it back into a string just to read its codepoint.
+      # That is around four objects per character, and it runs over the whole
+      # sublog of every test case at the end of a run: 28 million objects, and
+      # 98MB of permanently grown ruby heap, for a 6MB suite.
+      string.gsub(INVALID_XML_CHARS) { |char| "\\#{char.ord}" }
     end
 
     # Determine if the provided number falls in the range of accepted xml unicode values

--- a/spec/beaker/logger_junit_spec.rb
+++ b/spec/beaker/logger_junit_spec.rb
@@ -32,6 +32,31 @@ module Beaker
         testing_string = 'pants man, pants!'
         expect(described_class.escape_invalid_xml_chars(testing_string)).to be === testing_string
       end
+
+      it 'escapes carriage returns, which is_valid_xml does not accept' do
+        expect(described_class.escape_invalid_xml_chars("a\rb")).to be === 'a\13b'
+      end
+
+      it 'agrees with is_valid_xml on every codepoint' do
+        # INVALID_XML_CHARS has to track is_valid_xml rather than the spec that
+        # method cites, so walk the whole range instead of trusting either.
+        codepoints = (0..0xD7FF).to_a + (0xE000..0x10FFFF).to_a # surrogates cannot be in a String
+        codepoints.each_slice(50_000) do |slice|
+          string = slice.map { |c| c.chr(Encoding::UTF_8) }.join
+          expected = slice.map { |c| described_class.is_valid_xml(c) ? c.chr(Encoding::UTF_8) : "\\#{c}" }.join
+          expect(described_class.escape_invalid_xml_chars(string)).to eq(expected)
+        end
+      end
+
+      it 'accepts a frozen string' do
+        expect(described_class.escape_invalid_xml_chars('pants'.freeze)).to eq('pants')
+      end
+    end
+
+    describe '#format_cdata' do
+      it 'strips colour codes and escapes what is left' do
+        expect(described_class.format_cdata("\e[00;33mpants\e[00;00m")).to eq('pants')
+      end
     end
 
     describe '#copy_stylesheet_into_xml_dir' do


### PR DESCRIPTION
TestSuiteResult runs format_cdata over the sublog of every test case when it writes the junit report, and escape_invalid_xml_chars walked one character at a time, unpacking each one into an array and joining it back into a string just to read its codepoint. That is around four objects per character, over the whole log text of the whole run, at the point where the process is already at its largest. Measured over a real 6MB PE upgrade suite it allocated 28.4 million objects, took 3.9 seconds, and grew the ruby heap by 98MB that is never handed back. The same work as a single gsub is 30 thousand objects, 0.13 seconds and 2MB.

Match a character class rather than testing codepoints one at a time. That class has to track is_valid_xml rather than the specification it cites, since that method omits #xD and takes the last range as 0x100000 where the spec gives 0x10000. Both look like mistakes, but correcting either would change the contents of every junit report, so leave them alone and add a spec walking all 1112064 codepoints to keep the pattern and the method in step.

The new tests pass when run against old and new code, so there is no change in behavior.


(cherry picked from commit 8889d7fdd2a4a066198277d3f03cfd7f76cb79d9)