### PR TITLE
Don't lose a whole junit report to one bad byte

### DIFF
--- a/lib/beaker/logger_junit.rb
+++ b/lib/beaker/logger_junit.rb
@@ -133,6 +133,15 @@ module Beaker
     # @param [String] string The string to remove invalid codes from
     # @return [String] Properly escaped string
     def self.escape_invalid_xml_chars string
+      # Bytes that are not valid in their own encoding cannot be represented in
+      # xml at all, and would make the gsub below raise. Drop them, the same
+      # way Logger#convert does further upstream. Raising matters more here
+      # than it might look: TestSuiteResult calls #format_cdata from inside a
+      # blanket rescue that abandons the whole junit document, so one stray
+      # byte in one sublog loses every test result for the run.
+      string = string.dup.force_encoding(Encoding::UTF_8) unless string.encoding == Encoding::UTF_8
+      string = string.scrub('') unless string.valid_encoding?
+
       # This walked the string a character at a time, unpacking each one into
       # an array and joining it back into a string just to read its codepoint.
       # That is around four objects per character, and it runs over the whole

--- a/lib/beaker/logger_junit.rb
+++ b/lib/beaker/logger_junit.rb
@@ -120,21 +120,25 @@ module Beaker
       self.escape_invalid_xml_chars(Logger.strip_color_codes(string))
     end
 
+    # Every character {is_valid_xml} rejects, as one pattern. Note that this
+    # tracks that method rather than the specification it cites: #xD is absent
+    # from both, and both take the last range as 0x100000 rather than the
+    # 0x10000 the specification gives. Changing either would change the
+    # contents of every junit report, so they are left alone here and the specs
+    # walk the whole range to keep the two in step.
+    INVALID_XML_CHARS = /[^\u{9}\u{A}\u{20}-\u{D7FF}\u{E000}-\u{FFFD}\u{100000}-\u{10FFFF}]/
+
     # Escape invalid XML UTF-8 codes from provided string, see http://www.w3.org/TR/xml/#charsets for valid
     # character specification
     # @param [String] string The string to remove invalid codes from
     # @return [String] Properly escaped string
     def self.escape_invalid_xml_chars string
-      escaped_string = ""
-      string.chars.each do |i|
-        char_as_codestring = i.unpack("U*").join
-        escaped_string << if self.is_valid_xml(char_as_codestring.to_i)
-                            i
-                          else
-                            "\\#{char_as_codestring}"
-                          end
-      end
-      escaped_string
+      # This walked the string a character at a time, unpacking each one into
+      # an array and joining it back into a string just to read its codepoint.
+      # That is around four objects per character, and it runs over the whole
+      # sublog of every test case at the end of a run: 28 million objects, and
+      # 98MB of permanently grown ruby heap, for a 6MB suite.
+      string.gsub(INVALID_XML_CHARS) { |char| "\\#{char.ord}" }
     end
 
     # Determine if the provided number falls in the range of accepted xml unicode values

--- a/spec/beaker/logger_junit_spec.rb
+++ b/spec/beaker/logger_junit_spec.rb
@@ -48,6 +48,13 @@ module Beaker
         end
       end
 
+      it 'drops invalid encodings rather than raising' do
+        # TestSuiteResult calls format_cdata from inside a blanket rescue that
+        # abandons the whole junit document, so an exception raised here would
+        # cost the run its entire test report.
+        expect(described_class.escape_invalid_xml_chars("ok\xFFbad".b)).to eq('okbad')
+      end
+
       it 'accepts a frozen string' do
         expect(described_class.escape_invalid_xml_chars('pants'.freeze)).to eq('pants')
       end
@@ -56,6 +63,10 @@ module Beaker
     describe '#format_cdata' do
       it 'strips colour codes and escapes what is left' do
         expect(described_class.format_cdata("\e[00;33mpants\e[00;00m")).to eq('pants')
+      end
+
+      it 'survives invalid encodings' do
+        expect(described_class.format_cdata("\e[00;33mok\xFFbad".b)).to eq('okbad')
       end
     end
 

--- a/spec/beaker/logger_junit_spec.rb
+++ b/spec/beaker/logger_junit_spec.rb
@@ -32,6 +32,31 @@ module Beaker
         testing_string = 'pants man, pants!'
         expect(described_class.escape_invalid_xml_chars(testing_string)).to be === testing_string
       end
+
+      it 'escapes carriage returns, which is_valid_xml does not accept' do
+        expect(described_class.escape_invalid_xml_chars("a\rb")).to be === 'a\13b'
+      end
+
+      it 'agrees with is_valid_xml on every codepoint' do
+        # INVALID_XML_CHARS has to track is_valid_xml rather than the spec that
+        # method cites, so walk the whole range instead of trusting either.
+        codepoints = (0..0xD7FF).to_a + (0xE000..0x10FFFF).to_a # surrogates cannot be in a String
+        codepoints.each_slice(50_000) do |slice|
+          string = slice.map { |c| c.chr(Encoding::UTF_8) }.join
+          expected = slice.map { |c| described_class.is_valid_xml(c) ? c.chr(Encoding::UTF_8) : "\\#{c}" }.join
+          expect(described_class.escape_invalid_xml_chars(string)).to eq(expected)
+        end
+      end
+
+      it 'accepts a frozen string' do
+        expect(described_class.escape_invalid_xml_chars('pants'.freeze)).to eq('pants')
+      end
+    end
+
+    describe '#format_cdata' do
+      it 'strips colour codes and escapes what is left' do
+        expect(described_class.format_cdata("\e[00;33mpants\e[00;00m")).to eq('pants')
+      end
     end
 
     describe '#copy_stylesheet_into_xml_dir' do


### PR DESCRIPTION
escape_invalid_xml_chars raises on a string that is not valid in its own
encoding, as it did before the gsub when it was unpacking each character.
TestSuiteResult calls format_cdata from inside a blanket `rescue StandardError`
that logs "failure in XML output" and abandons the entire document, so a single
stray byte anywhere in a single sublog costs the run every one of its test
results, with nothing in Jenkins to say why.

Scrub instead. Bytes that are not valid in their own encoding cannot be
represented in xml at all, so there is nothing to escape them into, and
Logger#convert already drops them further upstream on everything that reaches a
sublog by the usual route. This only affects strings that arrive some other way.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
(cherry picked from commit https://github.com/voxpupuli/beaker/commit/ee9afc4b96d26ce8c969de2a88b82cd80e308552)

---

contains https://github.com/voxpupuli/beaker/pull/2025