### PR TITLE
Ensure correct encoding for logging and fix performance bugs

### DIFF
--- a/lib/beaker/logger.rb
+++ b/lib/beaker/logger.rb
@@ -197,7 +197,7 @@ module Beaker
       else
         # Remove invalid and undefined UTF-8 character encodings
         string = string.to_s.dup.force_encoding('UTF-8')
-        return string.to_s.chars.select { |i| i.valid_encoding? }.join
+        string.scrub('')
       end
     end
 

--- a/lib/beaker/result.rb
+++ b/lib/beaker/result.rb
@@ -31,10 +31,24 @@ module Beaker
       return string.gsub(/\r\n?/, "\n")
     end
 
-    def convert string
-      # Remove invalid and undefined UTF-8 character encodings
-      string.to_s.force_encoding('UTF-8')
-      string.to_s.chars.select { |i| i.valid_encoding? }.join
+    # This method behaves differently when given a string instance, subclass
+    # or something else. The latter two cases should be deprecated.
+    def convert(string)
+      # guard against nil, which never worked on accident
+      raise TypeError, "Beaker::Result#convert cannot convert nil to a String" if string.nil?
+
+      unless string.instance_of?(String)
+        # For a string subclass, `string.to_s` returns a copy, so calling
+        # `force_encoding` on it was meaningless.
+        return string.to_s.scrub('')
+      end
+
+      # Data collected from the connection is binary (ASCII-8BIT). In that
+      # encoding, every byte is a valid character, so we tag the string as UTF-8
+      string.force_encoding('UTF-8')
+
+      # And remove invalid and undefined UTF-8 character encodings.
+      string.scrub('')
     end
 
     def log(logger)

--- a/spec/beaker/logger_spec.rb
+++ b/spec/beaker/logger_spec.rb
@@ -24,6 +24,24 @@ module Beaker
         valid_utf8.freeze
         expect(logger.convert(valid_utf8)).to be === valid_utf8
       end
+
+      it 'leaves the string it was given alone' do
+        expect(logger.convert(invalid_utf8)).not_to equal(invalid_utf8)
+        expect(invalid_utf8.bytes).to include(0xAD)
+      end
+
+      it 'converts each item of an array' do
+        expect(logger.convert([valid_utf8, invalid_utf8])).to eq([valid_utf8, valid_utf8])
+      end
+
+      it 'converts arrays of arrays' do
+        expect(logger.convert([[invalid_utf8], valid_utf8])).to eq([[valid_utf8], valid_utf8])
+      end
+
+      it 'converts anything that can describe itself' do
+        expect(logger.convert(42)).to eq('42')
+        expect(logger.convert(nil)).to eq('')
+      end
     end
 
     describe '#generate_dated_log_folder' do

--- a/spec/beaker/result_spec.rb
+++ b/spec/beaker/result_spec.rb
@@ -69,8 +69,8 @@ module Beaker
           expect(result.convert(5)).to eq('5')
         end
 
-        it 'raises FrozenError on nil' do
-          expect { result.convert(nil) }.to raise_error(FrozenError, /modify frozen String: ""/)
+        it 'raises TypeError on nil' do
+          expect { result.convert(nil) }.to raise_error(TypeError, /cannot convert nil to a String/)
         end
       end
     end

--- a/spec/beaker/result_spec.rb
+++ b/spec/beaker/result_spec.rb
@@ -1,0 +1,189 @@
+require 'spec_helper'
+
+module Beaker
+  describe Result do
+    subject(:result) { described_class.new(host, cmd) }
+
+    let(:host) { 'my_host' }
+    let(:cmd)  { 'ls -la' }
+
+    # Command output reaches a Result the way net-ssh hands it over: as chunks
+    # of binary data, appended as they arrive.
+    def binary(string)
+      string.dup.force_encoding('ASCII-8BIT')
+    end
+
+    describe '#initialize' do
+      it 'starts with empty streams and no exit code' do
+        expect(result.stdout).to eq('')
+        expect(result.stderr).to eq('')
+        expect(result.output).to eq('')
+        expect(result.exit_code).to be_nil
+      end
+    end
+
+    describe '#convert' do
+      let(:valid_utf8) { "modules\n├── jimmy-appleseed (v1.1.0)\n└── jimmy-crakorn (v0.4.0)\n" }
+
+      it 'preserves valid utf-8' do
+        expect(result.convert(valid_utf8.dup)).to eq(valid_utf8)
+      end
+
+      it 'strips invalid utf-8 byte sequences' do
+        expect(result.convert(binary("ok\xFFbad"))).to eq('okbad')
+      end
+
+      it 'strips a truncated multi-byte sequence' do
+        expect(result.convert(binary("ok\xE3\x81"))).to eq('ok')
+      end
+
+      it 'returns utf-8 whatever encoding it was handed' do
+        expect(result.convert(binary('plain')).encoding).to eq(Encoding::UTF_8)
+      end
+
+      it 'modifies the argument encoding in place' do
+        string = binary('plain')
+        result.convert(string)
+        expect(string.encoding).to eq(Encoding::UTF_8)
+      end
+
+      it 'returns a new string rather than scrubbing the one it was given' do
+        string = binary("ok\xFFbad")
+        expect(result.convert(string)).not_to equal(string)
+        expect(string.bytes).to include(0xFF)
+      end
+
+      context 'when handed String subclass' do
+        let(:string_subclass) { Class.new(String) }
+
+        it 'accepts String subclass' do
+          expect(result.convert(string_subclass.new('plain'))).to eq('plain')
+        end
+
+        it 'leaves invalid encodings in place, as it always has' do
+          subclass = string_subclass.new(binary("ok\xFFbad"))
+          expect(result.convert(subclass).bytes).to include(0xFF)
+        end
+
+        it 'converts anything else that can describe itself' do
+          expect(result.convert(5)).to eq('5')
+        end
+
+        it 'raises FrozenError on nil' do
+          expect { result.convert(nil) }.to raise_error(FrozenError, /modify frozen String: ""/)
+        end
+      end
+    end
+
+    describe '#normalize_line_endings' do
+      it 'converts crlf to lf' do
+        expect(result.normalize_line_endings("a\r\nb")).to eq("a\nb")
+      end
+
+      it 'converts a lone cr to lf' do
+        expect(result.normalize_line_endings("a\rb")).to eq("a\nb")
+      end
+
+      it 'leaves lf alone' do
+        expect(result.normalize_line_endings("a\nb")).to eq("a\nb")
+      end
+    end
+
+    describe '#finalize!' do
+      before do
+        result.stdout << binary("out\xFF\r\n")
+        result.stderr << binary("err\xFF\r\n")
+        result.output << binary("out\xFF\r\nerr\xFF\r\n")
+        result.finalize!
+      end
+
+      it 'scrubs and normalizes every stream' do
+        expect(result.stdout).to eq("out\n")
+        expect(result.stderr).to eq("err\n")
+        expect(result.output).to eq("out\nerr\n")
+      end
+
+      it 'keeps the unscrubbed bytes in the raw_ attributes' do
+        expect(result.raw_stdout.bytes).to include(0xFF)
+        expect(result.raw_stderr.bytes).to include(0xFF)
+        expect(result.raw_output.bytes).to include(0xFF)
+      end
+
+      it 'leaves the raw_ line endings alone' do
+        expect(result.raw_stdout).to include("\r\n")
+      end
+    end
+
+    describe '#formatted_output' do
+      before do
+        result.output << (1..15).map { |i| "line #{i}" }.join("\n")
+      end
+
+      it 'returns the last ten lines by default, tab indented' do
+        expect(result.formatted_output).to eq((6..15).map { |i| "\tline #{i}" }.join("\n"))
+      end
+
+      it 'honours a limit' do
+        expect(result.formatted_output(2)).to eq("\tline 14\n\tline 15")
+      end
+    end
+
+    describe '#exit_code_in?' do
+      it 'is true when the exit code is in the range' do
+        result.exit_code = 2
+        expect(result.exit_code_in?([0, 2])).to be true
+      end
+
+      it 'is false when it is not' do
+        result.exit_code = 1
+        expect(result.exit_code_in?([0, 2])).to be false
+      end
+    end
+
+    describe '#success?' do
+      it 'is true only for an exit code of zero' do
+        result.exit_code = 0
+        expect(result).to be_success
+      end
+
+      it 'is false for a non-zero exit code' do
+        result.exit_code = 1
+        expect(result).not_to be_success
+      end
+
+      it 'is false when no exit code was collected' do
+        expect(result).not_to be_success
+      end
+    end
+
+    describe '#log' do
+      let(:logger) { instance_double(Beaker::Logger) }
+
+      it 'reports a non-zero exit code' do
+        result.exit_code = 1
+        expect(logger).to receive(:debug).with('Exited: 1')
+        result.log(logger)
+      end
+
+      it 'says nothing for a successful command' do
+        result.exit_code = 0
+        expect(logger).not_to receive(:debug)
+        result.log(logger)
+      end
+
+      it 'says nothing when no exit code was collected' do
+        expect(logger).not_to receive(:debug)
+        result.log(logger)
+      end
+    end
+  end
+
+  describe NullResult do
+    subject(:result) { described_class.new('my_host', 'ls -la') }
+
+    it 'succeeds without having run anything' do
+      expect(result.exit_code).to eq(0)
+      expect(result).to be_success
+    end
+  end
+end


### PR DESCRIPTION
* valid utf-8 strings are preserved
* invalid and truncated UTF-8 sequences are removed
* convert(5) returns "5"
* convert(str) modifies the encoding of the str argument! because String#to_s
  returns self.
* convert(nil) raises FrozenError, because nil.to_s returns a frozen empty
  string, so you can't call 'force_encoding' on it.
* add coverage for normalization, formatted_output, exit_code_in?, etc

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
(cherry picked from commit https://github.com/voxpupuli/beaker/commit/021220fb62cef4e44ce86824911acb4fc71a550e)

---

finalize! runs convert over stdout, stderr and output, and convert removed
invalid UTF-8 with `chars.select { |i| i.valid_encoding? }.join`. That builds an
array holding one String object for every character of the output, then a second
array for the ones it keeps, then joins them. A command producing 10MB of output
allocated 10.4 million objects and took 1.92 seconds, three times over per
result. String#scrub is the same operation in a single pass: 11 objects, and too
fast to measure.

The two are byte-identical across plain ascii, valid multi-byte UTF-8, lone
continuation bytes, truncated and overlong sequences, trailing invalid bytes and
a raw 0-255 blob. The one difference is that an empty string comes back tagged
UTF-8 rather than US-ASCII, which is what the non-empty ascii case already did.

The convert method now handles its arguments differently:

* If given a String instance, it force_encodes and scrubs directly.

* If given a subclass of String, it skips the useless to_s.force_encoding call,
as that modified the encoding of the String copy, and discarded it.

* If given nil, we raise a TypeError. Previously, it raised FrozenError due
to nil.to_s returning a frozen string, so the call to force_encoding raised.
Since this never worked, it's not a breaking change.

This does not address how much output a Result holds on to. stdout and stderr
are each also appended to output as they arrive, and finalize! keeps the
pre-scrub bytes in raw_stdout, raw_stderr and raw_output, so a finished result
retains roughly four times the output it collected.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
(cherry picked from commit https://github.com/voxpupuli/beaker/commit/18e3cbb8ec932e1d24788a20a3bfdfbf1cb70869)

---

convert removed invalid UTF-8 with `chars.select { |i| i.valid_encoding? }.join`,
the same way Result#convert did, allocating one String object for every character
it was handed. This is far cheaper per call than it was there, because the logger
sees host output in net-ssh sized chunks rather than whole commands, so only a
chunk's worth of objects is ever live at once and the heap does not balloon. It
still came to 7.6 million objects over a 7.6MB run. String#scrub is the same
operation in a single pass.

Measured over the console output of a real PE upgrade run, in 16KB chunks:

                            before        after
  objects allocated      7,647,447         2,812
  time                       0.91s         0.00s
  peak RSS                 30.7 MB       29.2 MB
  permanent heap            1.4 MB        0.2 MB

This changes no behaviour. The output is identical across all 1112064 unicode
codepoints, and for nil, integers, symbols, frozen strings, subclasses of String,
arrays and arrays of arrays. The one difference is that an empty string comes
back tagged UTF-8 rather than US-ASCII, which is what the non-empty ascii case
already did. Every spec here, including the new ones, passes against the previous
implementation as well.

Unlike Result#convert, nothing else needed changing. The dup already keeps the
caller's string from being retagged and keeps a frozen one from raising, nil and
subclasses of String were already handled correctly, and the second to_s was
merely redundant rather than load bearing, since the reassignment above it has
already produced a plain String.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
(cherry picked from commit https://github.com/voxpupuli/beaker/commit/9e0d475acaf9fc3c2eabae41d8ed4347a8028557)