### PR TITLE
Install iproute for ss for serverspec on Fedora

### DIFF
--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -129,8 +129,10 @@ module Beaker
         @version.to_i >= 11 ? %w[curl] : %w[CSWcurl wget]
       when 'archlinux'
         %w[curl net-tools openssh]
-      when 'amazon', 'amazonfips', 'fedora'
+      when 'amazon', 'amazonfips'
         ['iputils']
+      when 'fedora'
+        %w[iputils iproute]
       when 'aix', 'osx', 'windows'
         []
       else

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -332,7 +332,7 @@ describe Beaker do
     it "can validate Fedora hosts" do
       host = make_host('host', { :platform => 'fedora-32-x86_64' })
 
-      ['iputils'].each do |pkg|
+      ['iputils', 'iproute'].each do |pkg|
         expect(host).to receive(:check_for_package).with(pkg).once.and_return(false)
         expect(host).to receive(:install_package).with(pkg).once
       end


### PR DESCRIPTION
The serverspec:

```ruby
describe port('9868') do
  it { is_expected.to be_listening }
end
```

On Fedora `serverspec` uses `ss` to check if a port is open.

Ensure package `iproute` is always installed on Fedora acceptance tests.

See:

* https://github.com/voxpupuli/puppet-cvmfs/issues/250
* https://github.com/mizzy/specinfra/blob/master/lib/specinfra/command/redhat/base/port.rb
* https://github.com/mizzy/specinfra/blob/master/lib/specinfra/command/redhat/v7/port.rb
* https://github.com/mizzy/specinfra/blob/master/lib/specinfra/command/module/ss.rb