### PR TITLE
Install rootfiles on EL 8+ hosts

### DIFF
--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -120,7 +120,7 @@ module Beaker
     def base_packages
       case @variant
       when 'el'
-        @version.to_i >= 8 ? ['iputils'] : %w[curl]
+        @version.to_i >= 8 ? %w[iputils rootfiles] : %w[curl]
       when 'debian'
         %w[curl lsb-release]
       when 'freebsd'

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -276,7 +276,7 @@ describe Beaker do
     it "can validate el-9 hosts" do
       host = make_host('host', { :platform => 'el-9-64' })
 
-      ['iputils'].each do |pkg|
+      %w[iputils rootfiles].each do |pkg|
         expect(host).to receive(:check_for_package).with(pkg).once.and_return(false)
         expect(host).to receive(:install_package).with(pkg).once
       end
@@ -321,7 +321,7 @@ describe Beaker do
     it "can validate RHEL8 hosts" do
       host = make_host('host', { :platform => 'el-8-64' })
 
-      ['iputils'].each do |pkg|
+      %w[iputils rootfiles].each do |pkg|
         expect(host).to receive(:check_for_package).with(pkg).once.and_return(false)
         expect(host).to receive(:install_package).with(pkg).once
       end


### PR DESCRIPTION
## Summary

Add `rootfiles` to the EL 8+ `base_packages` list.

The CentOS Stream 9 and 10 container images (`quay.io/centos/centos:stream9` / `:stream10`) rebuilt on 2026-09-02 no longer include the `rootfiles` package, so `/root/.bashrc` does not exist. Commands run over ssh start a non-interactive bash, which only sources `/etc/bashrc` (and from there `/etc/profile.d/*.sh`) via `~/.bashrc`. Without that file, anything that relies on `/etc/profile.d` to extend `PATH` (e.g. `/etc/profile.d/puppet-agent.sh` from `puppet-agent`/`openvox-agent`) silently stops working and every beaker-docker acceptance run on those images fails at the first `puppet` call:

```
bash: line 1: puppet: command not found
```

Tell-tale sign in the beaker log: `cat ~/.ssh/environment` shows `PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin` on the broken images, versus `PATH=/root/.local/bin:/root/bin:/usr/local/sbin:...` on images where `~/.bashrc` was sourced.

Rocky, Alma, Oracle and UBI images still ship `rootfiles`, so this is a no-op there.

## Notes

- On EL 9+ `rootfiles` is tmpfiles-based: the dotfiles are `%ghost` entries created from `/usr/share/rootfiles` by systemd-tmpfiles at boot (or by the systemd rpm file trigger when installed on a running system). That covers both the beaker-docker image-build path (`additional_packages` in the generated Dockerfile, populated at container boot) and `validate_host` on an already-running host.
- Verified against a real module acceptance suite with `docker_centos9` (`quay.io/centos/centos:stream9`, `docker_cmd: ['/usr/sbin/init']`): fails without this change, 19 examples / 0 failures with it.
- `ip: command not found` also shows up on these images (`iproute` missing); #2031 added `iproute` for Fedora only. I'll follow up with a separate PR for EL once this one lands to avoid conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
