### PR TITLE
Install iproute on EL 8+ hosts

### DIFF
--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -120,7 +120,7 @@ module Beaker
     def base_packages
       case @variant
       when 'el'
-        @version.to_i >= 8 ? %w[iputils rootfiles] : %w[curl]
+        @version.to_i >= 8 ? %w[iputils iproute rootfiles] : %w[curl]
       when 'debian'
         %w[curl lsb-release]
       when 'freebsd'

--- a/spec/beaker/host_prebuilt_steps_spec.rb
+++ b/spec/beaker/host_prebuilt_steps_spec.rb
@@ -276,7 +276,7 @@ describe Beaker do
     it "can validate el-9 hosts" do
       host = make_host('host', { :platform => 'el-9-64' })
 
-      %w[iputils rootfiles].each do |pkg|
+      %w[iputils iproute rootfiles].each do |pkg|
         expect(host).to receive(:check_for_package).with(pkg).once.and_return(false)
         expect(host).to receive(:install_package).with(pkg).once
       end
@@ -321,7 +321,7 @@ describe Beaker do
     it "can validate RHEL8 hosts" do
       host = make_host('host', { :platform => 'el-8-64' })
 
-      %w[iputils rootfiles].each do |pkg|
+      %w[iputils iproute rootfiles].each do |pkg|
         expect(host).to receive(:check_for_package).with(pkg).once.and_return(false)
         expect(host).to receive(:install_package).with(pkg).once
       end


### PR DESCRIPTION
## Summary

Add `iproute` to the EL 8+ `base_packages` list.

Beaker runs `ip -o -4 addr show` on every host (`get_ip`), but the EL container images (CentOS Stream, Rocky, Alma, Oracle, UBI) do not ship `iproute`, so every EL beaker-docker run logs:

```
bash: line 1: ip: command not found
```

This is the EL counterpart of #2031, which added `iproute` for Fedora. Follow-up to #2033, split out to avoid conflicts as discussed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
