### PR TITLE
Fix NTP on Ubuntu 26.04 by using chrony

### DIFF
--- a/lib/beaker/platform.rb
+++ b/lib/beaker/platform.rb
@@ -111,6 +111,9 @@ module Beaker
         @version.to_i >= 8
       when 'debian'
         @version.to_i >= 13
+      when 'ubuntu'
+        # version may be '2604' or '26.04'
+        @version.delete('.').to_i >= 2604
       else
         false
       end


### PR DESCRIPTION
Ubuntu 26.04 does not include the `ntpdate` package anymore; it should use `chrony`.

